### PR TITLE
Added new style for displaying housenumbers & sped up generation of GetCapabilties document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,14 @@ STYLE?=default
 template=osmbase.map
 
 includes=land.map landusage.map borders.map highways.map places.map \
-         symbols-aeroways.map symbols-amenities.map symbols-stations.map \
-		 generated/$(STYLE)style.msinc \
-		 generated/$(STYLE)level0.msinc generated/$(STYLE)level1.msinc generated/$(STYLE)level2.msinc generated/$(STYLE)level3.msinc \
-		 generated/$(STYLE)level4.msinc generated/$(STYLE)level5.msinc generated/$(STYLE)level6.msinc generated/$(STYLE)level7.msinc \
-		 generated/$(STYLE)level8.msinc generated/$(STYLE)level9.msinc generated/$(STYLE)level10.msinc generated/$(STYLE)level11.msinc \
-		 generated/$(STYLE)level12.msinc generated/$(STYLE)level13.msinc generated/$(STYLE)level14.msinc generated/$(STYLE)level15.msinc \
-		 generated/$(STYLE)level16.msinc generated/$(STYLE)level17.msinc generated/$(STYLE)level18.msinc
+		housenumbers.map \
+		symbols-aeroways.map symbols-amenities.map symbols-stations.map \
+		generated/$(STYLE)style.msinc \
+		generated/$(STYLE)level0.msinc generated/$(STYLE)level1.msinc generated/$(STYLE)level2.msinc generated/$(STYLE)level3.msinc \
+		generated/$(STYLE)level4.msinc generated/$(STYLE)level5.msinc generated/$(STYLE)level6.msinc generated/$(STYLE)level7.msinc \
+		generated/$(STYLE)level8.msinc generated/$(STYLE)level9.msinc generated/$(STYLE)level10.msinc generated/$(STYLE)level11.msinc \
+		generated/$(STYLE)level12.msinc generated/$(STYLE)level13.msinc generated/$(STYLE)level14.msinc generated/$(STYLE)level15.msinc \
+		generated/$(STYLE)level16.msinc generated/$(STYLE)level17.msinc generated/$(STYLE)level18.msinc
 
 
 

--- a/borders.map
+++ b/borders.map
@@ -1,97 +1,97 @@
 #if _display_admin == 1
-LAYER
-   GROUP "default"
-   STATUS ON
-   MAXSCALEDENOM _maxscale
-   MINSCALEDENOM _minscale
-   TYPE LINE
-   NAME layername(admin_fr,_layer_suffix)
-   DATA _admin_data
-   CLASS
-      STYLE
-         COLOR _admin_clr
-         WIDTH _admin_width
-      END
-   END
-END
+	LAYER
+		GROUP "default"
+		STATUS ON
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		TYPE LINE
+		NAME layername(admin_fr,_layer_suffix)
+		DATA _admin_data
+		CLASS
+			STYLE
+				COLOR _admin_clr
+				WIDTH _admin_width
+			END
+		END
+	END
 #endif
 
-LAYER
-   GROUP "default"
-   STATUS ON
-   MAXSCALEDENOM _maxscale
-   MINSCALEDENOM _minscale
-   TYPE LINE
-   NAME layername(borders,_layer_suffix)
-   PROJECTION
-     _border_epsg
-   END
-   DATA _border_data
+	LAYER
+		GROUP "default"
+		STATUS ON
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		TYPE LINE
+		NAME layername(borders,_layer_suffix)
+		PROJECTION
+			_border_epsg
+		END
+		DATA _border_data
 #if _display_border_2 == 1
-   CLASS
+		CLASS
 #if _display_border_2_outer == 1
-      STYLE
-         WIDTH _border_2_width
-         COLOR _border_2_clr
-         OPACITY 50
-      END
+			STYLE
+				WIDTH _border_2_width
+				COLOR _border_2_clr
+				OPACITY 50
+			END
 #endif
-      STYLE
-         WIDTH _border_2_inner_width
-         COLOR _border_2_inner_clr
-         _border_2_inner_pattern
-      END
-   END
+			STYLE
+				WIDTH _border_2_inner_width
+				COLOR _border_2_inner_clr
+				_border_2_inner_pattern
+			END
+		END
 #endif
 #if _display_border_4 == 1
-   CLASS
-      EXPRESSION "4"
+		CLASS
+			EXPRESSION "4"
 #if _display_border_4_outer == 1
-      STYLE
-         WIDTH _border_4_width
-         COLOR _border_4_clr
-         OPACITY 50
-      END
+			STYLE
+				WIDTH _border_4_width
+				COLOR _border_4_clr
+				OPACITY 50
+			END
 #endif
-      STYLE
-         WIDTH _border_4_inner_width
-         COLOR _border_4_inner_clr
-         _border_4_inner_pattern
-      END
-   END
+			STYLE
+				WIDTH _border_4_inner_width
+				COLOR _border_4_inner_clr
+				_border_4_inner_pattern
+			END
+		END
 #endif
 #if _display_border_6 == 1
-   CLASS
-      EXPRESSION "6"
+		CLASS
+			EXPRESSION "6"
 #if _display_border_6_outer == 1
-      STYLE
-         WIDTH _border_6_width
-         COLOR _border_6_clr
-         OPACITY 50
-      END
+			STYLE
+				WIDTH _border_6_width
+				COLOR _border_6_clr
+				OPACITY 50
+			END
 #endif
-      STYLE
-         WIDTH _border_6_inner_width
-         COLOR _border_6_inner_clr
-         _border_6_inner_pattern
-      END
-   END
+			STYLE
+				WIDTH _border_6_inner_width
+				COLOR _border_6_inner_clr
+				_border_6_inner_pattern
+			END
+		END
 #endif
 #if _display_border_8 == 1
-   CLASS
-      EXPRESSION "8"
+		CLASS
+			EXPRESSION "8"
 #if _display_border_8_outer == 1
-      STYLE
-         WIDTH _border_8_width
-         COLOR _border_8_clr
-         OPACITY 50
-      END
+			STYLE
+				WIDTH _border_8_width
+				COLOR _border_8_clr
+				OPACITY 50
+			END
 #endif
-      STYLE
-         WIDTH _border_8_inner_width
-         COLOR _border_8_inner_clr
-         _border_8_inner_pattern
-      END
-   END
+			STYLE
+				WIDTH _border_8_inner_width
+				COLOR _border_8_inner_clr
+				_border_8_inner_pattern
+			END
+		END
 #endif
-END
+	END

--- a/buildings.map
+++ b/buildings.map
@@ -1,47 +1,47 @@
 #if _display_buildings == 1
-LAYER
-    STATUS ON
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    GROUP "default"
-    NAME layername(buildings,_layer_suffix)
-    TYPE POLYGON
-    CONNECTIONTYPE postgis
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		STATUS ON
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		GROUP "default"
+		NAME layername(buildings,_layer_suffix)
+		TYPE POLYGON
+		CONNECTIONTYPE postgis
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA "geometry from (select geometry,osm_id, OSM_NAME_COLUMN as name from OSM_PREFIX_buildings) as foo using unique osm_id using srid=OSM_SRID"
-    LABELITEM "name"
-    PROCESSING "LABEL_NO_CLIP=ON"
-    PROCESSING "CLOSE_CONNECTION=DEFER"
-    MAXSCALEDENOM _maxscale
-    MINSCALEDENOM _minscale
-    CLASS
-      STYLE
-         COLOR _building_clr
-         OPACITY 50
-      END
-      STYLE
-         OUTLINECOLOR _building_ol_clr
-         WIDTH _building_ol_width
-      END
+		DATA "geometry from (select geometry,osm_id, OSM_NAME_COLUMN as name from OSM_PREFIX_buildings) as foo using unique osm_id using srid=OSM_SRID"
+		LABELITEM "name"
+		PROCESSING "LABEL_NO_CLIP=ON"
+		PROCESSING "CLOSE_CONNECTION=DEFER"
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		CLASS
+			STYLE
+				COLOR _building_clr
+				OPACITY 50
+			END
+			STYLE
+				OUTLINECOLOR _building_ol_clr
+				WIDTH _building_ol_width
+			END
 #if _label_buildings == 1
-      LABEL
-         TYPE TRUETYPE
-         FONT _building_font
-         PARTIALS FALSE
-         MINFEATURESIZE AUTO
-         SIZE _building_lbl_size
-         COLOR _building_lbl_clr
-         OUTLINECOLOR _building_lbl_ol_clr
-         OUTLINEWIDTH _building_lbl_ol_width
-         WRAP ' '
-         MAXLENGTH 6
-         ALIGN CENTER
-      END
+			LABEL
+				TYPE TRUETYPE
+				FONT _building_font
+				PARTIALS FALSE
+				MINFEATURESIZE AUTO
+				SIZE _building_lbl_size
+				COLOR _building_lbl_clr
+				OUTLINECOLOR _building_lbl_ol_clr
+				OUTLINEWIDTH _building_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+			END
 #endif
-   END
-END
+		END
+	END
 #endif

--- a/generate_style.py
+++ b/generate_style.py
@@ -1328,22 +1328,10 @@ namedstyles = {
 			0: '"way from (select way, osm_id, tunnel, railway as type from OSM_PREFIX_line where railway=\'rail\') as foo using unique osm_id using srid=OSM_SRID"'
 		},
 		'landusage_data': {
-			0: '"way from (select way, osm_id, name, type from (select way, st_area(way) as area, osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'wood\',\'residential\')\
-         order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
-			6: '"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'wood\',\'industrial\',\'commercial\',\'residential\')\
-         order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
-			9: '"way from (select way, osm_id, name, type from (select way, st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
-         \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
-         \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
-         \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
-			12: '"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 \
-         where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\
-         \'brownfield\',\'residential\',\'school\',\'college\',\'university\',\
-         \'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\
-         \'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"'
+			0: '"way from (select way, osm_id, name, type from (select way, st_area(way) as area, osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 where type in (\'forest\',\'wood\',\'residential\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
+			6: '"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 where type in (\'forest\',\'wood\',\'industrial\',\'commercial\',\'residential\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
+			9: '"way from (select way, osm_id, name, type from (select way, st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\'brownfield\',\'residential\',\'school\',\'college\',\'university\',\'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"',
+			12: '"way from (select way, osm_id, name, type from (select way , st_area(way) as area ,osm_id, (case when landuse is not null then landuse else (case when \\\"natural\\\" is not null then \\\"natural\\\" else (case when leisure is not null then leisure else amenity end) end) end) as type, OSM_NAME_COLUMN as name from OSM_PREFIX_polygon) as osm2 where type in (\'forest\',\'wood\',\'pedestrian\',\'cemetery\',\'industrial\',\'commercial\',\'brownfield\',\'residential\',\'school\',\'college\',\'university\',\'military\',\'park\',\'golf_course\',\'hospital\',\'parking\',\'stadium\',\'sports_center\',\'pitch\') order by area desc) as foo using unique osm_id using srid=OSM_SRID"'
 		},
 		'roads_data': {
 			0: '"way from (select osm_id,way,OSM_NAME_COLUMN as name,ref,highway as type, 0 as tunnel, 0 as bridge from OSM_PREFIX_line where highway in (\'motorway\',\'trunk\') order by z_order asc, st_length(way) asc) as foo using unique osm_id using srid=OSM_SRID"',
@@ -1353,7 +1341,6 @@ namedstyles = {
 			11: '"way from (select osm_id,way,OSM_NAME_COLUMN as name,ref,highway as type, 0 as tunnel, 0 as bridge from OSM_PREFIX_line where highway is not null order by z_order asc, st_length(way) asc) as foo using unique osm_id using srid=OSM_SRID"',
 			14: '"way from (select osm_id,way,OSM_NAME_COLUMN as name,ref,highway||(case when bridge=\'yes\' then 1 else 0 end)||(case when tunnel=\'yes\' then 1 else 0 end) as type from OSM_PREFIX_line where highway is not null order by z_order asc, st_length(way) asc) as foo using unique osm_id using srid=OSM_SRID"',
 		},
-
 	},
 	'bw': {
 		'park_clr': "0 0 0",
@@ -1646,6 +1633,28 @@ namedstyles = {
 
 		'display_peak_lbl': {0: 0, 13: 1}
 		# todo: all symbols here ?
+	},
+	'housenumbers': {
+		# begin displaying housenumbers at z17
+		'display_housenumbers': {0: 0, 17: 1},
+
+
+		'housenumbers_data': {
+			0: 'nodata',
+			17: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, type AS label, osm_id FROM OSM_PREFIX_housenumbers) AS numbers) as foo using unique osm_id using srid=OSM_SRID"',
+			18: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, CASE WHEN name <> \'\' AND type <> \'\' THEN name || \' (\' || type || \')\' WHEN name <> \'\' THEN name ELSE type END AS label, osm_id FROM OSM_PREFIX_housenumbers) AS numbers) as foo using unique osm_id using srid=OSM_SRID"'
+		},
+
+		'housenumbers_lbl_size': {
+			0: 0,
+			17: 8,
+			18: 6
+		},
+		'housenumbers_lbl_clr': '100 100 100',
+		'housenumbers_lbl_ol_clr': '255 255 255',
+		'housenumbers_lbl_ol_width': 1.0,
+		'housenumbers_lbl_txt': "'[label]'",
+		'housenumbers_lbl_font': "NotoSansUIRegular"
 	}
 }
 
@@ -1671,7 +1680,13 @@ style_aliases = {
 	"defaultsymbols": "default,symbols",
 	"googlesymbols": "default,outlined,google,symbols",
 	"michelinsymbols": "default,outlined,centerlined,michelin,symbols",
-	"bingsymbols": "default,outlined,bing,symbols"
+	"bingsymbols": "default,outlined,bing,symbols",
+
+	# a style adding housenumbers
+	"defaultsymbolshousenumbers": "default,symbols,housenumbers",
+	"googlesymbolshousenumbers": "default,outlined,google,symbols,housenumbers",
+	"michelinsymbolshousenumbers": "default,outlined,centerlined,michelin,symbols,housenumbers",
+	"bingsymbolshousenumbers": "default,outlined,bing,symbols,housenumbers"
 }
 
 parser = argparse.ArgumentParser()

--- a/highways.map
+++ b/highways.map
@@ -1,959 +1,888 @@
 #if _display_railways == 1
-LAYER
-    GROUP "default"
-    STATUS ON
-    CONNECTIONTYPE POSTGIS
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE LINE
-    NAME layername(railways,_layer_suffix)
-    DATA _railways_data
-    CLASSITEM "tunnel"
-    CLASS
-      EXPRESSION "0"
-        STYLE
-         WIDTH _railway_width
-         COLOR _railway_clr
-         OUTLINEWIDTH _railway_ol_width
-         OUTLINECOLOR _railway_ol_clr
-         PATTERN _railway_pattern END
-         LINECAP BUTT
-        END
-    END
-    CLASS
-        STYLE
-         WIDTH _railway_width
-         COLOR _railway_clr
-         PATTERN _railway_pattern END
-         OPACITY _railway_tunnel_opacity
-         LINECAP BUTT
-        END
-    END
-END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE LINE
+		NAME layername(railways,_layer_suffix)
+		DATA _railways_data
+		CLASSITEM "tunnel"
+		CLASS
+			EXPRESSION "0"
+			STYLE
+				WIDTH _railway_width
+				COLOR _railway_clr
+				OUTLINEWIDTH _railway_ol_width
+				OUTLINECOLOR _railway_ol_clr
+				PATTERN _railway_pattern END
+				LINECAP BUTT
+			END
+		END
+		CLASS
+			STYLE
+				WIDTH _railway_width
+				COLOR _railway_clr
+				PATTERN _railway_pattern END
+				OPACITY _railway_tunnel_opacity
+				LINECAP BUTT
+			END
+		END
+	END
 #endif
 
 #if _display_highways == 1
-
-LAYER
-    GROUP "default"
-    STATUS ON
-    TYPE LINE
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    NAME layername(roads,_layer_suffix)
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    CONNECTIONTYPE postgis
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		GROUP "default"
+		STATUS ON
+		TYPE LINE
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		NAME layername(roads,_layer_suffix)
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		CONNECTIONTYPE postgis
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA _roads_data
-    LABELITEM "name"
-    CLASSITEM "type"
+		DATA _roads_data
+		LABELITEM "name"
+		CLASSITEM "type"
 
-########################################
-## small roads, no tunnels or bridges ##
-########################################
-
+		########################################
+		## small roads, no tunnels or bridges ##
+		########################################
 #if _display_other_roads == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION {unclassified00,residential00,service00,road00,living_street00}
+			EXPRESSION {unclassified00,residential00,service00,road00,living_street00}
 #else
-        EXPRESSION {unclassified,residential,service,road,living_street}
+			EXPRESSION {unclassified,residential,service,road,living_street}
 #endif
 #if _display_other_outline
-        STYLE
-           WIDTH _other_width
-           OUTLINEWIDTH _other_ol_width
-           OUTLINECOLOR _other_ol_clr
-        END
+			STYLE
+				WIDTH _other_width
+				OUTLINEWIDTH _other_ol_width
+				OUTLINECOLOR _other_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _other_width
-            COLOR _other_clr
-        END
+			STYLE
+				WIDTH _other_width
+				COLOR _other_clr
+			END
 #if _label_other_roads == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _other_font
-            SIZE _other_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            ANGLE FOLLOW
-            COLOR _other_lbl_clr
-            OUTLINECOLOR _other_lbl_ol_clr
-            OUTLINEWIDTH _other_lbl_ol_width
-            ENCODING "UTF-8"
-            MINFEATURESIZE AUTO
-            BUFFER 3
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _other_font
+				SIZE _other_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				ANGLE FOLLOW
+				COLOR _other_lbl_clr
+				OUTLINECOLOR _other_lbl_ol_clr
+				OUTLINEWIDTH _other_lbl_ol_width
+				ENCODING "UTF-8"
+				MINFEATURESIZE AUTO
+				BUFFER 3
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-
-##################################################
-## tracks                                       ##
-##################################################
-
+		##################################################
+		## tracks                                       ##
+		##################################################
 #if _display_tracks == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "track00"
+			EXPRESSION "track00"
 #else
-        EXPRESSION "track"
+			EXPRESSION "track"
 #endif
 #if _display_track_outline
-        STYLE
-           WIDTH _track_width
-           OUTLINEWIDTH _track_ol_width
-           OUTLINECOLOR _track_ol_clr
-        END
+			STYLE
+				WIDTH _track_width
+				OUTLINEWIDTH _track_ol_width
+				OUTLINECOLOR _track_ol_clr
+			END
 #endif
-        STYLE
-            PATTERN _track_pattern END
-            WIDTH _track_width
-            COLOR _track_clr
-        END
+			STYLE
+				PATTERN _track_pattern END
+				WIDTH _track_width
+				COLOR _track_clr
+			END
 #if _label_track == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _track_font
-            SIZE _track_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            ANGLE FOLLOW
-            COLOR _track_lbl_clr
-            OUTLINECOLOR _track_lbl_ol_clr
-            OUTLINEWIDTH _track_lbl_ol_width
-            MINFEATURESIZE AUTO
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _track_font
+				SIZE _track_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				ANGLE FOLLOW
+				COLOR _track_lbl_clr
+				OUTLINECOLOR _track_lbl_ol_clr
+				OUTLINEWIDTH _track_lbl_ol_width
+				MINFEATURESIZE AUTO
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-
-##################################################
-## tertiary roads, simple                       ##
-##################################################
-
+		##################################################
+		## tertiary roads, simple                       ##
+		##################################################
 #if _display_tertiaries == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION {tertiary00,tertiary_link00}
+			EXPRESSION {tertiary00,tertiary_link00}
 #else
-        EXPRESSION {tertiary,tertiary_link}
+			EXPRESSION {tertiary,tertiary_link}
 #endif
 #if _display_tertiary_outline
-        STYLE
-           WIDTH _tertiary_width
-           OUTLINEWIDTH _tertiary_ol_width
-           OUTLINECOLOR _tertiary_ol_clr
-        END
+			STYLE
+				WIDTH _tertiary_width
+				OUTLINEWIDTH _tertiary_ol_width
+				OUTLINECOLOR _tertiary_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _tertiary_width
-            COLOR _tertiary_clr
-        END
+			STYLE
+				WIDTH _tertiary_width
+				COLOR _tertiary_clr
+			END
 #if _label_tertiaries == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _tertiary_font
-            SIZE _tertiary_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            ANGLE FOLLOW
-            COLOR _tertiary_lbl_clr
-            OUTLINECOLOR _tertiary_lbl_ol_clr
-            OUTLINEWIDTH _tertiary_lbl_ol_width
-            MINFEATURESIZE AUTO
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _tertiary_font
+				SIZE _tertiary_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				ANGLE FOLLOW
+				COLOR _tertiary_lbl_clr
+				OUTLINECOLOR _tertiary_lbl_ol_clr
+				OUTLINEWIDTH _tertiary_lbl_ol_width
+				MINFEATURESIZE AUTO
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-
-##################################################
-## secondary roads, simple                      ##
-##################################################
-
+		##################################################
+		## secondary roads, simple                      ##
+		##################################################
 #if _display_secondaries == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION {secondary00,secondary_link00}
+			EXPRESSION {secondary00,secondary_link00}
 #else
-        EXPRESSION {secondary,secondary_link}
+			EXPRESSION {secondary,secondary_link}
 #endif
 #if _display_secondary_outline
-        STYLE
-           WIDTH _secondary_width
-           OUTLINEWIDTH _secondary_ol_width
-           OUTLINECOLOR _secondary_ol_clr
-        END
+			STYLE
+			WIDTH _secondary_width
+			OUTLINEWIDTH _secondary_ol_width
+			OUTLINECOLOR _secondary_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _secondary_width
-            COLOR _secondary_clr
-        END
+			STYLE
+				WIDTH _secondary_width
+				COLOR _secondary_clr
+			END
 #if _label_secondaries == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE 
-            FONT _secondary_font
-            SIZE _secondary_lbl_size 
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            ANGLE FOLLOW
-            COLOR _secondary_lbl_clr
-            OUTLINECOLOR _secondary_lbl_ol_clr
-            OUTLINEWIDTH _secondary_lbl_ol_width
-            MINFEATURESIZE AUTO
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE 
+				FONT _secondary_font
+				SIZE _secondary_lbl_size 
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				ANGLE FOLLOW
+				COLOR _secondary_lbl_clr
+				OUTLINECOLOR _secondary_lbl_ol_clr
+				OUTLINEWIDTH _secondary_lbl_ol_width
+				MINFEATURESIZE AUTO
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-########################################
-## cycleway ##
-########################################
-
+		########################################
+		## cycleway ##
+		########################################
 #if _display_cycleways == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "cycleway00"
+			EXPRESSION "cycleway00"
 #else
-        EXPRESSION "cycleway"
+			EXPRESSION "cycleway"
 #endif
 #if _display_other_outline
-        STYLE
-           WIDTH _cycleway_width
-           OUTLINEWIDTH _cycleway_ol_width
-           OUTLINECOLOR _cycleway_ol_clr
-        END
+			STYLE
+				WIDTH _cycleway_width
+				OUTLINEWIDTH _cycleway_ol_width
+				OUTLINECOLOR _cycleway_ol_clr
+			END
 #endif
-        STYLE
-            PATTERN _cycleway_pattern END
-            WIDTH _cycleway_width
-            COLOR _cycleway_clr
-        END
-    END
+			STYLE
+				PATTERN _cycleway_pattern END
+				WIDTH _cycleway_width
+				COLOR _cycleway_clr
+			END
+		END
 #endif
 
-
-##################################################
-## footways                                     ##
-##################################################
-
+		##################################################
+		## footways                                     ##
+		##################################################
 #if _display_footways == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION {footway00,path00}
+			EXPRESSION {footway00,path00}
 #else
-        EXPRESSION {footway,path}
+			EXPRESSION {footway,path}
 #endif
 #if _display_footway_outline
-        STYLE
-           WIDTH _footway_width
-           OUTLINEWIDTH _footway_ol_width
-           OUTLINECOLOR _footway_ol_clr
-        END
+			STYLE
+				WIDTH _footway_width
+				OUTLINEWIDTH _footway_ol_width
+				OUTLINECOLOR _footway_ol_clr
+			END
 #endif
-        STYLE
-            PATTERN _footway_pattern END
-            WIDTH _footway_width
-            COLOR _footway_clr
-        END
-    END
+			STYLE
+				PATTERN _footway_pattern END
+				WIDTH _footway_width
+				COLOR _footway_clr
+			END
+		END
 #endif
 
-##################################################
-## piers                                        ##
-##################################################
-
+		##################################################
+		## piers                                        ##
+		##################################################
 #if _display_piers == 1
-    CLASS
-        EXPRESSION {pier,pier00,pier10}
+		CLASS
+			EXPRESSION {pier,pier00,pier10}
 #if _display_pier_outline
-        STYLE
-           WIDTH _pier_width
-           OUTLINEWIDTH _pier_ol_width
-           OUTLINECOLOR _pier_ol_clr
-        END
-#endif
-        STYLE
-            WIDTH _pier_width
-            COLOR _pier_clr
-        END
-    END
-#endif
+			STYLE
+				WIDTH _pier_width
+				OUTLINEWIDTH _pier_ol_width
+				OUTLINECOLOR _pier_ol_clr
+			END
+	#endif
+			STYLE
+				WIDTH _pier_width
+				COLOR _pier_clr
+			END
+		END
+	#endif
 
-
-
-##################################################
-## primary roads, simple                        ##
-##################################################
+		##################################################
+		## primary roads, simple                        ##
+		##################################################
 #if _display_primaries == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION {primary00,primary_link00}
+			EXPRESSION {primary00,primary_link00}
 #else
-        EXPRESSION {primary,primary_link}
+			EXPRESSION {primary,primary_link}
 #endif
 #if _display_primary_outline
-        STYLE
-           WIDTH _primary_width
-           OUTLINEWIDTH _primary_ol_width
-           OUTLINECOLOR _primary_ol_clr
-        END
+			STYLE
+				WIDTH _primary_width
+				OUTLINEWIDTH _primary_ol_width
+				OUTLINECOLOR _primary_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _primary_width 
-            COLOR _primary_clr
-        END
+			STYLE
+				WIDTH _primary_width 
+				COLOR _primary_clr
+			END
 #if _label_primaries == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _primary_font
-            SIZE _primary_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            MINFEATURESIZE AUTO
-            COLOR _primary_lbl_clr
-            OUTLINECOLOR _primary_lbl_ol_clr
-            OUTLINEWIDTH _primary_lbl_ol_width
-            ANGLE FOLLOW
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _primary_font
+				SIZE _primary_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				MINFEATURESIZE AUTO
+				COLOR _primary_lbl_clr
+				OUTLINECOLOR _primary_lbl_ol_clr
+				OUTLINEWIDTH _primary_lbl_ol_width
+				ANGLE FOLLOW
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-##################################################
-## pedestrian streets, simple                   ##
-##################################################
-
+		##################################################
+		## pedestrian streets, simple                   ##
+		##################################################
 #if _display_pedestrian == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION 'pedestrian00'
+			EXPRESSION 'pedestrian00'
 #else
-        EXPRESSION 'pedestrian'
+			EXPRESSION 'pedestrian'
 #endif
 #if _display_pedestrian_outline
-        STYLE
-           WIDTH _pedestrian_width
-           OUTLINEWIDTH _pedestrian_ol_width
-           OUTLINECOLOR _pedestrian_ol_clr
-        END
+			STYLE
+				WIDTH _pedestrian_width
+				OUTLINEWIDTH _pedestrian_ol_width
+				OUTLINECOLOR _pedestrian_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _pedestrian_width 
-            COLOR _pedestrian_clr
-        END
+			STYLE
+				WIDTH _pedestrian_width 
+				COLOR _pedestrian_clr
+			END
 #if _label_pedestrian == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _pedestrian_font
-            SIZE _pedestrian_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            ANGLE FOLLOW
-            COLOR _pedestrian_lbl_clr
-            OUTLINECOLOR _pedestrian_lbl_ol_clr
-            OUTLINEWIDTH _pedestrian_lbl_ol_width
-            MINFEATURESIZE AUTO
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _pedestrian_font
+				SIZE _pedestrian_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				ANGLE FOLLOW
+				COLOR _pedestrian_lbl_clr
+				OUTLINECOLOR _pedestrian_lbl_ol_clr
+				OUTLINEWIDTH _pedestrian_lbl_ol_width
+				MINFEATURESIZE AUTO
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-
-##################################################
-## motorways, simple                            ##
-##################################################
-
+		##################################################
+		## motorways, simple                            ##
+		##################################################
 #if _display_motorways == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "motorway00"
+			EXPRESSION "motorway00"
 #else
-        EXPRESSION "motorway"
+			EXPRESSION "motorway"
 #endif
-        TEXT ("[ref]")
+			TEXT ("[ref]")
 #if _display_motorway_outline
-        STYLE
-           WIDTH _motorway_width
-           OUTLINEWIDTH _motorway_ol_width
-           OUTLINECOLOR _motorway_ol_clr
-        END
+			STYLE
+				WIDTH _motorway_width
+				OUTLINEWIDTH _motorway_ol_width
+				OUTLINECOLOR _motorway_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _motorway_width
-            COLOR _motorway_clr
-        END
+			STYLE
+				WIDTH _motorway_width
+				COLOR _motorway_clr
+			END
 #if _display_motorway_centerline
-        STYLE
-           WIDTH _motorway_centerline_width
-           COLOR _motorway_centerline_clr
-        END
+			STYLE
+				WIDTH _motorway_centerline_width
+				COLOR _motorway_centerline_clr
+			END
 #endif
 #if _label_motorways == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            PRIORITY 1
-            FONT _motorway_font
-            SIZE _motorway_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            MINFEATURESIZE AUTO
-            COLOR _motorway_lbl_clr
-            ANGLE FOLLOW
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				PRIORITY 1
+				FONT _motorway_font
+				SIZE _motorway_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				MINFEATURESIZE AUTO
+				COLOR _motorway_lbl_clr
+				ANGLE FOLLOW
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-##################################################
-## motorway links, simple                       ##
-##################################################
-
+		##################################################
+		## motorway links, simple                       ##
+		##################################################
 #if _display_motorway_links == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "motorway_link00"
+			EXPRESSION "motorway_link00"
 #else
-        EXPRESSION "motorway_link"
+			EXPRESSION "motorway_link"
 #endif
 #if _display_motorway_outline
-        STYLE
-           WIDTH _primary_width
-           OUTLINEWIDTH _motorway_ol_width
-           OUTLINECOLOR _motorway_ol_clr
-        END
+			STYLE
+				WIDTH _primary_width
+				OUTLINEWIDTH _motorway_ol_width
+				OUTLINECOLOR _motorway_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _primary_width
-            COLOR _motorway_clr
-        END
-    END
+			STYLE
+				WIDTH _primary_width
+				COLOR _motorway_clr
+			END
+		END
 #endif
 
-
-
-
-##################################################
-## trunks, simple                               ##
-##################################################
-
+		##################################################
+		## trunks, simple                               ##
+		##################################################
 #if _display_trunks == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "trunk00"
+			EXPRESSION "trunk00"
 #else
-        EXPRESSION "trunk"
+			EXPRESSION "trunk"
 #endif
-        TEXT ("[ref]")
+			TEXT ("[ref]")
 #if _display_trunk_outline
-        STYLE
-           WIDTH _trunk_width
-           OUTLINEWIDTH _trunk_ol_width
-           OUTLINECOLOR _trunk_ol_clr
-        END
+			STYLE
+			WIDTH _trunk_width
+			OUTLINEWIDTH _trunk_ol_width
+			OUTLINECOLOR _trunk_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _trunk_width 
-            COLOR _trunk_clr
-        END
+			STYLE
+				WIDTH _trunk_width 
+				COLOR _trunk_clr
+			END
 #if _display_trunk_centerline
-        STYLE
-           WIDTH _trunk_centerline_width
-           COLOR _trunk_centerline_clr
-        END
+			STYLE
+			WIDTH _trunk_centerline_width
+			COLOR _trunk_centerline_clr
+			END
 #endif
 #if _label_trunks == 1
-        LABEL
-            TYPE TRUETYPE
-            PARTIALS FALSE
-            FONT _trunk_font
-            SIZE _trunk_lbl_size
-            MINDISTANCE 200
-            REPEATDISTANCE 400
-            MINFEATURESIZE AUTO
-            COLOR _trunk_lbl_clr
-            ANGLE FOLLOW
-            BUFFER 3
-            ENCODING "UTF-8"
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _trunk_font
+				SIZE _trunk_lbl_size
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				MINFEATURESIZE AUTO
+				COLOR _trunk_lbl_clr
+				ANGLE FOLLOW
+				BUFFER 3
+				ENCODING "UTF-8"
+			END
 #endif
-    END
+		END
 #endif
 
-
-
-
-##################################################
-## trunk links, simple                          ##
-##################################################
-
+		##################################################
+		## trunk links, simple                          ##
+		##################################################
 #if _display_trunk_links == 1
-    CLASS
+		CLASS
 #if _display_bridges == 1
-        EXPRESSION "trunk_link00"
+			EXPRESSION "trunk_link00"
 #else
-        EXPRESSION "trunk_link"
+			EXPRESSION "trunk_link"
 #endif
 #if _display_trunk_outline
-        STYLE
-           WIDTH _primary_width
-           OUTLINEWIDTH _trunk_ol_width
-           OUTLINECOLOR _trunk_ol_clr
-        END
+			STYLE
+				WIDTH _primary_width
+				OUTLINEWIDTH _trunk_ol_width
+				OUTLINECOLOR _trunk_ol_clr
+			END
 #endif
-        STYLE
-            WIDTH _primary_width
-            COLOR _trunk_clr
-        END
-    END
+			STYLE
+				WIDTH _primary_width
+				COLOR _trunk_clr
+			END
+		END
 #endif
 
-
-
-###########################################################
-##                                                       ##
-##   Bridges and tunnels                                 ##
-##                                                       ##
-###########################################################
-
+		###########################################################
+		##                                                       ##
+		##   Bridges and tunnels                                 ##
+		##                                                       ##
+		###########################################################
 #if _display_bridges == 1
-
-
-##########################
-## other roads, bridges ##
-##########################
+		##########################
+		## other roads, bridges ##
+		##########################
 #if _display_other_roads == 1
-    CLASS
-        EXPRESSION {unclassified10,residential10,service10,road10,living_street10}
+		CLASS
+			EXPRESSION {unclassified10,residential10,service10,road10,living_street10}
 #if _display_other_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _other_width
-            OUTLINECOLOR _other_bridge_clr
-            OUTLINEWIDTH _other_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _other_width
-            COLOR _other_clr
-        END
-    END
+			STYLE
+				WIDTH _other_width
+				OUTLINECOLOR _other_bridge_clr
+				OUTLINEWIDTH _other_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _other_width
+				COLOR _other_clr
+			END
+		END
 #endif
 
-
-##########################
-## tertiaries, bridges  ##
-##########################
+		##########################
+		## tertiaries, bridges  ##
+		##########################
 #if _display_tertiaries == 1
-    CLASS
-        EXPRESSION {tertiary10,tertiary_link10}
+		CLASS
+			EXPRESSION {tertiary10,tertiary_link10}
 #if _display_tertiary_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _tertiary_width
-            OUTLINECOLOR _tertiary_bridge_clr
-            OUTLINEWIDTH _tertiary_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _tertiary_width
-            COLOR _tertiary_clr
-        END
-    END
+			STYLE
+				WIDTH _tertiary_width
+				OUTLINECOLOR _tertiary_bridge_clr
+				OUTLINEWIDTH _tertiary_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _tertiary_width
+				COLOR _tertiary_clr
+			END
+		END
 #endif
 
-
-
-###########################
-## secondaries, bridges  ##
-###########################
+		###########################
+		## secondaries, bridges  ##
+		###########################
 #if _display_secondaries == 1
-    CLASS
-        EXPRESSION {secondary10,secondary_link10}
+		CLASS
+			EXPRESSION {secondary10,secondary_link10}
 #if _display_secondary_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _secondary_width
-            OUTLINECOLOR _secondary_bridge_clr
-            OUTLINEWIDTH _secondary_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _secondary_width
-            COLOR _secondary_clr
-        END
-    END
+			STYLE
+				WIDTH _secondary_width
+				OUTLINECOLOR _secondary_bridge_clr
+				OUTLINEWIDTH _secondary_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _secondary_width
+				COLOR _secondary_clr
+			END
+		END
 #endif
 
-
-
-########################
-## primaries, bridges ##
-########################
+		########################
+		## primaries, bridges ##
+		########################
 #if _display_primaries == 1
-    CLASS
-        EXPRESSION {primary10,primary_link10}
+		CLASS
+			EXPRESSION {primary10,primary_link10}
 #if _display_primary_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _primary_width
-            OUTLINECOLOR _primary_bridge_clr
-            OUTLINEWIDTH _primary_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _primary_width
-            COLOR _primary_clr 
-        END
-    END
-#endif
+			STYLE
+				WIDTH _primary_width
+				OUTLINECOLOR _primary_bridge_clr
+				OUTLINEWIDTH _primary_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _primary_width
+				COLOR _primary_clr 
+			END
+		END
+	#endif
 
-
-########################
-## pedestrian bridges ##
-########################
+		########################
+		## pedestrian bridges ##
+		########################
 #if _display_pedestrian == 1
-    CLASS
-        EXPRESSION {pedestrian10,footway10,path10}
+		CLASS
+			EXPRESSION {pedestrian10,footway10,path10}
 #if _display_pedestrian_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _pedestrian_width 
-            OUTLINECOLOR _pedestrian_bridge_clr
-            OUTLINEWIDTH _pedestrian_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _pedestrian_width 
-            COLOR _pedestrian_clr
-        END
-    END
+			STYLE
+				WIDTH _pedestrian_width 
+				OUTLINECOLOR _pedestrian_bridge_clr
+				OUTLINEWIDTH _pedestrian_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _pedestrian_width 
+				COLOR _pedestrian_clr
+			END
+		END
 #endif
 
-########################
-## motorways, bridges ##
-########################
+		########################
+		## motorways, bridges ##
+		########################
 #if _display_motorways == 1
-    CLASS
-        EXPRESSION "motorway10"
+		CLASS
+			EXPRESSION "motorway10"
 #if _display_motorway_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _motorway_width
-            OUTLINECOLOR _motorway_bridge_clr
-            OUTLINEWIDTH _motorway_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _motorway_width
-            COLOR _motorway_clr
-        END
-    END
+			STYLE
+				WIDTH _motorway_width
+				OUTLINECOLOR _motorway_bridge_clr
+				OUTLINEWIDTH _motorway_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _motorway_width
+				COLOR _motorway_clr
+			END
+		END
 #endif
 #if _display_motorway_links == 1
-    CLASS
-        EXPRESSION "motorway_link10"
+		CLASS
+			EXPRESSION "motorway_link10"
 #if _display_motorway_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _primary_width
-            OUTLINECOLOR _motorway_bridge_clr
-            OUTLINEWIDTH _primary_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _primary_width
-            COLOR _motorway_clr
-        END
-    END
+			STYLE
+				WIDTH _primary_width
+				OUTLINECOLOR _motorway_bridge_clr
+				OUTLINEWIDTH _primary_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _primary_width
+				COLOR _motorway_clr
+			END
+		END
 #endif
 
-
-
-####################
-## trunk, bridges ##
-####################
+		####################
+		## trunk, bridges ##
+		####################
 #if _display_trunks == 1
-    CLASS
-        EXPRESSION "trunk10"
+		CLASS
+			EXPRESSION "trunk10"
 #if _display_trunk_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _trunk_width
-            OUTLINECOLOR _trunk_bridge_clr
-            OUTLINEWIDTH _trunk_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _trunk_width
-            COLOR _trunk_clr 
-        END
-    END
+			STYLE
+				WIDTH _trunk_width
+				OUTLINECOLOR _trunk_bridge_clr
+				OUTLINEWIDTH _trunk_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _trunk_width
+				COLOR _trunk_clr 
+			END
+		END
 #endif
 #if _display_trunk_links == 1
-    CLASS
-        EXPRESSION "trunk_link10"
+		CLASS
+			EXPRESSION "trunk_link10"
 #if _display_trunk_outline
-        STYLE
-        END
+			STYLE
+			END
 #endif
-        STYLE
-            WIDTH _primary_width
-            OUTLINECOLOR _trunk_bridge_clr
-            OUTLINEWIDTH _trunk_bridge_width
-            LINECAP BUTT
-        END
-        STYLE
-            WIDTH _primary_width
-            COLOR _trunk_clr
-        END
-    END
+			STYLE
+				WIDTH _primary_width
+				OUTLINECOLOR _trunk_bridge_clr
+				OUTLINEWIDTH _trunk_bridge_width
+				LINECAP BUTT
+			END
+			STYLE
+				WIDTH _primary_width
+				COLOR _trunk_clr
+			END
+		END
 #endif
 
-
-
-
-
-
-########################
-## small road tunnels ##
-########################
+		########################
+		## small road tunnels ##
+		########################
 #if _display_other_roads == 1
-    CLASS
-        EXPRESSION {unclassified01,residential01,service01,living_street01}
-        STYLE
-            WIDTH _other_width
-            COLOR _other_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION {unclassified01,residential01,service01,living_street01}
+			STYLE
+				WIDTH _other_width
+				COLOR _other_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-########################
-## pedestrian tunnels ##
-########################
+		########################
+		## pedestrian tunnels ##
+		########################
 #if _display_pedestrian == 1
-    CLASS
-        EXPRESSION {pedestrian01,footway01,path01}
-        STYLE
-            WIDTH _pedestrian_width 
-            COLOR _pedestrian_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION {pedestrian01,footway01,path01}
+			STYLE
+				WIDTH _pedestrian_width 
+				COLOR _pedestrian_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-
-
-
-######################
-## tertiary tunnels ##
-######################
+		######################
+		## tertiary tunnels ##
+		######################
 #if _display_tertiaries == 1
-    CLASS
-        EXPRESSION {tertiary01,tertiary_link01}
-        STYLE
-            WIDTH _tertiary_width
-            COLOR _tertiary_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION {tertiary01,tertiary_link01}
+			STYLE
+				WIDTH _tertiary_width
+				COLOR _tertiary_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-#######################
-## secondary tunnels ##
-#######################
+		#######################
+		## secondary tunnels ##
+		#######################
 #if _display_secondaries == 1
-    CLASS
-        EXPRESSION {secondary01,secondary_link01}
-        STYLE
-            WIDTH _secondary_width
-            COLOR _secondary_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION {secondary01,secondary_link01}
+			STYLE
+				WIDTH _secondary_width
+				COLOR _secondary_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-
-#####################
-## primary tunnels ##
-#####################
+		#####################
+		## primary tunnels ##
+		#####################
 #if _display_primaries == 1
-    CLASS
-        EXPRESSION {primary01,primary_link01}
-        STYLE
-            WIDTH _primary_width
-            COLOR _primary_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION {primary01,primary_link01}
+			STYLE
+				WIDTH _primary_width
+				COLOR _primary_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-
-######################
-## motorway tunnels ##
-######################
+		######################
+		## motorway tunnels ##
+		######################
 #if _display_motorways == 1
-    CLASS
-        EXPRESSION "motorway01"
-        STYLE
-            WIDTH _motorway_width
-            COLOR _motorway_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION "motorway01"
+			STYLE
+				WIDTH _motorway_width
+				COLOR _motorway_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 #if _display_motorway_links == 1
-    CLASS
-        EXPRESSION "motorway_link01"
-        STYLE
-            WIDTH _primary_width
-            COLOR _motorway_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION "motorway_link01"
+			STYLE
+				WIDTH _primary_width
+				COLOR _motorway_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 
-
-###################
-## trunk tunnels ##
-###################
+		###################
+		## trunk tunnels ##
+		###################
 #if _display_trunks == 1
-    CLASS
-        EXPRESSION "trunk01"
-        STYLE
-            WIDTH _trunk_width
-            COLOR _trunk_clr
-            OPACITY _tunnel_opacity
-        END
-    END
+		CLASS
+			EXPRESSION "trunk01"
+			STYLE
+				WIDTH _trunk_width
+				COLOR _trunk_clr
+				OPACITY _tunnel_opacity
+			END
+		END
 #endif
 #if _display_trunk_links == 1
-    CLASS
-        EXPRESSION "trunk_link01"
-        STYLE
-            WIDTH _primary_width
-            COLOR _trunk_clr
-            OPACITY _tunnel_opacity
-        END
-    END
-#endif
-
+		CLASS
+			EXPRESSION "trunk_link01"
+			STYLE
+				WIDTH _primary_width
+				COLOR _trunk_clr
+				OPACITY _tunnel_opacity
+			END
+		END
+	#endif
 #endif
 ##(display_roads_tunnels)
-END
-    
+	END
 
 #if _display_aeroways == 1
-LAYER
-    GROUP "default"
-    STATUS ON
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE LINE
-    NAME layername(aeroways,_layer_suffix)
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    CONNECTIONTYPE postgis
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		GROUP "default"
+		STATUS ON
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE LINE
+		NAME layername(aeroways,_layer_suffix)
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		CONNECTIONTYPE postgis
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA "geometry from (select geometry, osm_id, type from OSM_PREFIX_aeroways) as foo using unique osm_id using srid=OSM_SRID"
-    CLASSITEM "type"
-    CLASS
-      EXPRESSION "runway"
-      STYLE
-        COLOR _runway_clr
-        WIDTH _runway_width
-        LINECAP BUTT
-        LINEJOIN MITER
-      END
-      STYLE
-        COLOR _runway_center_clr
-        WIDTH _runway_center_width
-        PATTERN _runway_center_pattern END
-        LINECAP BUTT
-      END
-    END
-    CLASS
-      EXPRESSION "taxiway"
-      STYLE
-        COLOR _taxiway_clr
-        WIDTH _taxiway_width
-      END
-    END
-END
+		DATA "geometry from (select geometry, osm_id, type from OSM_PREFIX_aeroways) as foo using unique osm_id using srid=OSM_SRID"
+		CLASSITEM "type"
+		CLASS
+			EXPRESSION "runway"
+			STYLE
+				COLOR _runway_clr
+				WIDTH _runway_width
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+			STYLE
+				COLOR _runway_center_clr
+				WIDTH _runway_center_width
+				PATTERN _runway_center_pattern END
+				LINECAP BUTT
+			END
+			END
+			CLASS
+			EXPRESSION "taxiway"
+			STYLE
+				COLOR _taxiway_clr
+				WIDTH _taxiway_width
+			END
+		END
+	END
 #endif
-#endif    
+#endif

--- a/housenumbers.map
+++ b/housenumbers.map
@@ -1,0 +1,35 @@
+#if _display_housenumbers == 1
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE POINT
+#if OSM_FORCE_POSTGIS_EXTENT == 1
+		EXTENT OSM_EXTENT
+#endif
+		NAME layername(housenumbers,_layer_suffix)
+		DATA _housenumbers_data
+		CLASS
+			LABEL
+				SIZE _housenumbers_lbl_size
+				COLOR _housenumbers_lbl_clr
+				TEXT _housenumbers_lbl_txt
+				OUTLINECOLOR _housenumbers_lbl_ol_clr
+				OUTLINEWIDTH _housenumbers_lbl_ol_width
+				POSITION cc
+				FONT _housenumbers_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				ALIGN CENTER
+				WRAP ' '
+				FORCE FALSE
+			END
+		END
+	END
+#endif

--- a/land.map
+++ b/land.map
@@ -1,20 +1,20 @@
-LAYER
-   TYPE POLYGON
-   STATUS ON
-   GROUP "default"
-   DEBUG _layerdebug
-   NAME layername(land,_layer_suffix)
-   PROCESSING "APPROXIMATION_SCALE=full"
-   PROJECTION
-       _land_epsg
-   END
-   MINSCALEDENOM _minscale
-   MAXSCALEDENOM _maxscale
-   DATA _land_data
-   CLASS
-       STYLE
-           COLOR _land_clr
-       END
-   END
-END
+	LAYER
+		TYPE POLYGON
+		STATUS ON
+		GROUP "default"
+		DEBUG _layerdebug
+		NAME layername(land,_layer_suffix)
+		PROCESSING "APPROXIMATION_SCALE=full"
+		PROJECTION
+			_land_epsg
+		END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		DATA _land_data
+		CLASS
+			STYLE
+				COLOR _land_clr
+			END
+		END
+	END
 

--- a/landusage.map
+++ b/landusage.map
@@ -1,445 +1,444 @@
 #if _display_landusage == 1
-LAYER
-    TYPE POLYGON
-    STATUS ON
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    NAME layername(landuse,_layer_suffix)
-    GROUP "default"
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		TYPE POLYGON
+		STATUS ON
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		NAME layername(landuse,_layer_suffix)
+		GROUP "default"
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA _landusage_data
-    PROCESSING "LABEL_NO_CLIP=ON"
-    PROCESSING "CLOSE_CONNECTION=DEFER"
-    MAXSCALEDENOM _maxscale
-    MINSCALEDENOM _minscale
-    CLASSITEM "type"
-    LABELITEM "name"
+		DATA _landusage_data
+		PROCESSING "LABEL_NO_CLIP=ON"
+		PROCESSING "CLOSE_CONNECTION=DEFER"
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		CLASSITEM "type"
+		LABELITEM "name"
 #if _display_forest==1
-    CLASS
-       EXPRESSION {forest,wood}
-       STYLE
-          COLOR _forest_clr
-       END
+		CLASS
+			EXPRESSION {forest,wood}
+			STYLE
+				COLOR _forest_clr
+			END
 #if _display_forest_lbl==1
-      LABEL
-         TYPE TRUETYPE
-         FONT _forest_font
-         SIZE _forest_lbl_size
-         COLOR _forest_lbl_clr
-         OUTLINECOLOR _forest_lbl_ol_clr
-         OUTLINEWIDTH _forest_lbl_ol_width
-         WRAP ' '
-         MAXLENGTH 6
-         ALIGN CENTER
-         MINFEATURESIZE AUTO
-         PARTIALS FALSE
-      END
+			LABEL
+				TYPE TRUETYPE
+				FONT _forest_font
+				SIZE _forest_lbl_size
+				COLOR _forest_lbl_clr
+				OUTLINECOLOR _forest_lbl_ol_clr
+				OUTLINEWIDTH _forest_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				PARTIALS FALSE
+			END
 #endif
-    END
+		END
 #endif
 #if _display_residential==1
-    CLASS
-       EXPRESSION 'residential'
-       STYLE
-          COLOR _residential_clr
-          OUTLINECOLOR _residential_ol_clr
-          OUTLINEWIDTH _residential_ol_width
-       END
+		CLASS
+			EXPRESSION 'residential'
+			STYLE
+				COLOR _residential_clr
+				OUTLINECOLOR _residential_ol_clr
+				OUTLINEWIDTH _residential_ol_width
+			END
 #if _display_residential_lbl==1
-      LABEL
-         TYPE TRUETYPE
-         FONT _residential_font
-         SIZE _residential_lbl_size
-         COLOR _residential_lbl_clr
-         OUTLINECOLOR _residential_lbl_ol_clr
-         OUTLINEWIDTH _residential_lbl_ol_width
-         WRAP ' '
-         MAXLENGTH 6
-         ALIGN CENTER
-         MINFEATURESIZE AUTO
-         PARTIALS FALSE
-      END
+			LABEL
+				TYPE TRUETYPE
+				FONT _residential_font
+				SIZE _residential_lbl_size
+				COLOR _residential_lbl_clr
+				OUTLINECOLOR _residential_lbl_ol_clr
+				OUTLINEWIDTH _residential_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				PARTIALS FALSE
+			END
 #endif
-   END
+		END
 #endif
 #if _display_industrial==1
-   CLASS
-     EXPRESSION {industrial,commercial,parking}
-     STYLE
-       COLOR _industrial_clr
-       OUTLINECOLOR _industrial_ol_clr
-       OUTLINEWIDTH _industrial_ol_width
-     END
+		CLASS
+			EXPRESSION {industrial,commercial,parking}
+			STYLE
+				COLOR _industrial_clr
+				OUTLINECOLOR _industrial_ol_clr
+				OUTLINEWIDTH _industrial_ol_width
+			END
 #if _display_industrial_lbl==1
-     LABEL
-       ENCODING "utf-8"
-       TYPE TRUETYPE
-       FONT _industrial_font
-       SIZE _industrial_lbl_size
-       COLOR _industrial_lbl_clr
-       OUTLINECOLOR _industrial_lbl_ol_clr
-       OUTLINEWIDTH _pedestrian_lbl_ol_width
-       PRIORITY 2
-       WRAP ' '
-       MAXLENGTH 6
-       ALIGN CENTER
-       MINFEATURESIZE AUTO
-       PARTIALS FALSE
-     END
+			LABEL
+				ENCODING "utf-8"
+				TYPE TRUETYPE
+				FONT _industrial_font
+				SIZE _industrial_lbl_size
+				COLOR _industrial_lbl_clr
+				OUTLINECOLOR _industrial_lbl_ol_clr
+				OUTLINEWIDTH _pedestrian_lbl_ol_width
+				PRIORITY 2
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				PARTIALS FALSE
+			END
 #endif
-    END
+		END
 #endif
 #if _display_park==1
-    CLASS
-        EXPRESSION {park,golf_course}
-        STYLE
-            COLOR _park_clr
-        END
+		CLASS
+			EXPRESSION {park,golf_course}
+			STYLE
+				COLOR _park_clr
+			END
 #if _display_park_lbl==1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _park_font
-          SIZE _park_lbl_size
-       ENCODING "utf-8"
-          COLOR _park_lbl_clr
-          OUTLINECOLOR _park_lbl_ol_clr
-          OUTLINEWIDTH _park_lbl_ol_width
-          PRIORITY 2
-          POSITION cc
-          WRAP ' '
-          MAXLENGTH 6
-          ALIGN CENTER
-          MINFEATURESIZE AUTO
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _park_font
+				SIZE _park_lbl_size
+				ENCODING "utf-8"
+				COLOR _park_lbl_clr
+				OUTLINECOLOR _park_lbl_ol_clr
+				OUTLINEWIDTH _park_lbl_ol_width
+				PRIORITY 2
+				POSITION cc
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
+		END
 #endif
 #if _display_cemetery==1
-    CLASS
-        EXPRESSION 'cemetery'
-        STYLE
-          COLOR _cemetery_clr
-        END
+		CLASS
+			EXPRESSION 'cemetery'
+			STYLE
+				COLOR _cemetery_clr
+			END
 #if _display_cemetery_lbl==1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _cemetery_font
-       ENCODING "utf-8"
-            SIZE _cemetery_lbl_size
-            COLOR _cemetery_lbl_clr
-            OUTLINECOLOR _cemetery_lbl_ol_clr
-            OUTLINEWIDTH _cemetery_lbl_ol_width
-            PRIORITY 2
-            WRAP ' '
-            MAXLENGTH 6
-            ALIGN CENTER
-            MINFEATURESIZE AUTO
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _cemetery_font
+				ENCODING "utf-8"
+				SIZE _cemetery_lbl_size
+				COLOR _cemetery_lbl_clr
+				OUTLINECOLOR _cemetery_lbl_ol_clr
+				OUTLINEWIDTH _cemetery_lbl_ol_width
+				PRIORITY 2
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
+		END
 #endif
-   CLASS
-      EXPRESSION 'pedestrian'
-      STYLE
-         COLOR _pedestrian_clr
-      END
+		CLASS
+			EXPRESSION 'pedestrian'
+			STYLE
+				COLOR _pedestrian_clr
+			END
 #if _display_pedestrian_lbl==1
-      LABEL
-         TYPE TRUETYPE
-         FONT _pedestrian_font
-         SIZE _pedestrian_lbl_size
-         COLOR _pedestrian_lbl_clr
-         OUTLINECOLOR _pedestrian_lbl_ol_clr
-         OUTLINEWIDTH _pedestrian_lbl_ol_width
-         WRAP ' '
-         MAXLENGTH 6
-         ALIGN CENTER
-         MINFEATURESIZE AUTO
-         PARTIALS FALSE
-      END
+			LABEL
+				TYPE TRUETYPE
+				FONT _pedestrian_font
+				SIZE _pedestrian_lbl_size
+				COLOR _pedestrian_lbl_clr
+				OUTLINECOLOR _pedestrian_lbl_ol_clr
+				OUTLINEWIDTH _pedestrian_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				PARTIALS FALSE
+			END
 #endif
-   END
+		END
 #if _display_hospital==1
-    CLASS
-        EXPRESSION 'hospital'
-        STYLE
-            COLOR _hospital_clr
-        END
+		CLASS
+			EXPRESSION 'hospital'
+			STYLE
+				COLOR _hospital_clr
+			END
 #if _display_hospital_lbl==1
-         LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _hospital_font
-          SIZE _hospital_lbl_size
-          COLOR _hospital_lbl_clr
-          OUTLINECOLOR _hospital_lbl_ol_clr
-       ENCODING "utf-8"
-          OUTLINEWIDTH _hospital_lbl_ol_width
-          PRIORITY 1
-          WRAP ' '
-          MAXLENGTH 6
-          ALIGN CENTER
-          MINFEATURESIZE AUTO
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _hospital_font
+				SIZE _hospital_lbl_size
+				COLOR _hospital_lbl_clr
+				OUTLINECOLOR _hospital_lbl_ol_clr
+				ENCODING "utf-8"
+				OUTLINEWIDTH _hospital_lbl_ol_width
+				PRIORITY 1
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
+		END
 #endif
 #if _display_education==1
-    CLASS
-        EXPRESSION {school,college,university}
-        STYLE
-            COLOR _education_clr
-        END
+		CLASS
+			EXPRESSION {school,college,university}
+			STYLE
+				COLOR _education_clr
+			END
 #if _display_education_lbl==1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _education_font
-          SIZE _education_lbl_size
-       ENCODING "utf-8"
-          COLOR _education_lbl_clr
-          OUTLINECOLOR _education_lbl_ol_clr
-          OUTLINEWIDTH _education_lbl_ol_width
-          PRIORITY 1
-          WRAP ' '
-          MAXLENGTH 6
-          ALIGN CENTER
-          MINFEATURESIZE AUTO
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _education_font
+				SIZE _education_lbl_size
+				ENCODING "utf-8"
+				COLOR _education_lbl_clr
+				OUTLINECOLOR _education_lbl_ol_clr
+				OUTLINEWIDTH _education_lbl_ol_width
+				PRIORITY 1
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
+		END
 #endif
 #if _display_sports==1
-    CLASS
-      EXPRESSION {sports_center,stadium,pitch}
-      STYLE
-          COLOR _sports_clr
-      END
+		CLASS
+			EXPRESSION {sports_center,stadium,pitch}
+			STYLE
+				COLOR _sports_clr
+			END
 #if _display_sports_lbl==1
-      LABEL
-        TYPE TRUETYPE
-        PARTIALS FALSE
-        FONT _sports_font
-        SIZE _sports_lbl_size
-        COLOR _sports_lbl_clr
-        OUTLINECOLOR _sports_lbl_ol_clr
-       ENCODING "utf-8"
-        OUTLINEWIDTH _sports_lbl_ol_width
-        PRIORITY 1
-        WRAP ' '
-        MAXLENGTH 6
-        ALIGN CENTER
-        MINFEATURESIZE AUTO
-      END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _sports_font
+				SIZE _sports_lbl_size
+				COLOR _sports_lbl_clr
+				OUTLINECOLOR _sports_lbl_ol_clr
+				ENCODING "utf-8"
+				OUTLINEWIDTH _sports_lbl_ol_width
+				PRIORITY 1
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
+		END
 #endif
-END
+	END
 
 #if _display_transport_areas == 1
-LAYER
-   TYPE POLYGON
-   STATUS ON
-   PROJECTION
-       "init=epsg:OSM_SRID"
-   END
-   NAME layername(transport_areas,_layer_suffix)
-   GROUP "default"
-   CONNECTIONTYPE POSTGIS
-   CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		TYPE POLYGON
+		STATUS ON
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		NAME layername(transport_areas,_layer_suffix)
+		GROUP "default"
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-   DATA "geometry from OSM_PREFIX_transport_areas using unique osm_id using srid=OSM_SRID"
-   PROCESSING "CLOSE_CONNECTION=DEFER"
-   MAXSCALEDENOM _maxscale
-   MINSCALEDENOM _minscale
-   LABELITEM "name"
-   CLASS
-      STYLE
-         COLOR _transport_clr
-      END
+		DATA "geometry from OSM_PREFIX_transport_areas using unique osm_id using srid=OSM_SRID"
+		PROCESSING "CLOSE_CONNECTION=DEFER"
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		LABELITEM "name"
+		CLASS
+			STYLE
+				COLOR _transport_clr
+			END
 #if _display_transports_lbl==1
-      LABEL
-        TYPE TRUETYPE
-        PARTIALS FALSE
-        FONT _transport_font
-        SIZE _transport_lbl_size
-        COLOR _stransport_lbl_clr
-        OUTLINECOLOR _transport_lbl_ol_clr
-        OUTLINEWIDTH _transport_lbl_ol_width
-        PRIORITY 1
-        WRAP ' '
-        MAXLENGTH 6
-        ALIGN CENTER
-        MINFEATURESIZE AUTO
-      END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _transport_font
+				SIZE _transport_lbl_size
+				COLOR _stransport_lbl_clr
+				OUTLINECOLOR _transport_lbl_ol_clr
+				OUTLINEWIDTH _transport_lbl_ol_width
+				PRIORITY 1
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-   END
-END
-
+		END
+	END
 #endif
 
-LAYER
-    TYPE POLYGON
-    STATUS ON
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    NAME layername(waterarea,_layer_suffix)
-    GROUP "default"
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		TYPE POLYGON
+		STATUS ON
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		NAME layername(waterarea,_layer_suffix)
+		GROUP "default"
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA _waterarea_data
-    MAXSCALEDENOM _maxscale
-    MINSCALEDENOM _minscale  
-    PROCESSING "CLOSE_CONNECTION=DEFER"
-    LABELITEM "name"
-    CLASSITEM "type"
-    CLASS
-      EXPRESSION "riverbank"
+		DATA _waterarea_data
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale  
+		PROCESSING "CLOSE_CONNECTION=DEFER"
+		LABELITEM "name"
+		CLASSITEM "type"
+		CLASS
+			EXPRESSION "riverbank"
 #if _display_waterarea_outline
-        STYLE           
-           OUTLINECOLOR _waterarea_ol_clr
-           OUTLINEWIDTH _waterarea_ol_width
-        END
+			STYLE           
+				OUTLINECOLOR _waterarea_ol_clr
+				OUTLINEWIDTH _waterarea_ol_width
+			END
 #endif
-        STYLE
-            COLOR _waterarea_clr    
-        END
-    END
-    CLASS
+			STYLE
+				COLOR _waterarea_clr    
+			END
+		END
+		CLASS
 #if _display_waterarea_outline
-        STYLE           
-           OUTLINECOLOR _waterarea_ol_clr
-           OUTLINEWIDTH _waterarea_ol_width
-        END
+			STYLE           
+				OUTLINECOLOR _waterarea_ol_clr
+				OUTLINEWIDTH _waterarea_ol_width
+			END
 #endif
-        STYLE
-            COLOR _waterarea_clr    
-        END
+			STYLE
+				COLOR _waterarea_clr    
+			END
 #if _display_waterarea_lbl == 1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _waterarea_font
-          MINDISTANCE 200
-          SIZE _waterarea_lbl_size
-          COLOR _waterarea_lbl_clr
-       ENCODING "utf-8"
-          OUTLINECOLOR _waterarea_lbl_ol_clr
-          OUTLINEWIDTH _waterarea_lbl_ol_width
-          WRAP ' '
-          MAXLENGTH 5
-          ALIGN CENTER
-          MINFEATURESIZE AUTO
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _waterarea_font
+				MINDISTANCE 200
+				SIZE _waterarea_lbl_size
+				COLOR _waterarea_lbl_clr
+				ENCODING "utf-8"
+				OUTLINECOLOR _waterarea_lbl_ol_clr
+				OUTLINEWIDTH _waterarea_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 5
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+			END
 #endif
-    END
-END
+		END
+	END
 
 #if _display_waterways == 1
-LAYER
-    TYPE LINE
-    NAME layername(waterways,_layer_suffix)
-    STATUS ON
-    GROUP "default"
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		TYPE LINE
+		NAME layername(waterways,_layer_suffix)
+		STATUS ON
+		GROUP "default"
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
-    EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
-    DATA _waterways_data
-    CLASSITEM "type"
-    MAXSCALEDENOM _maxscale
-    MINSCALEDENOM _minscale
-    LABELITEM "name"
-    PROJECTION
-        "init=epsg:OSM_SRID"
-    END
-    PROCESSING "CLOSE_CONNECTION=DEFER"
-    CLASS
-        EXPRESSION "river"
-        STYLE
-            COLOR _river_clr 
-            WIDTH _river_width
-        END
+		DATA _waterways_data
+		CLASSITEM "type"
+		MAXSCALEDENOM _maxscale
+		MINSCALEDENOM _minscale
+		LABELITEM "name"
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		PROCESSING "CLOSE_CONNECTION=DEFER"
+		CLASS
+			EXPRESSION "river"
+			STYLE
+				COLOR _river_clr 
+				WIDTH _river_width
+			END
 #if _display_river_lbl == 1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _river_font
-          MINDISTANCE 200
-          SIZE _river_lbl_size
-          COLOR _river_lbl_clr
-          OUTLINECOLOR _river_lbl_ol_clr
-          OUTLINEWIDTH _river_lbl_ol_width
-          REPEATDISTANCE 400
-          ENCODING "utf-8"
-          MINFEATURESIZE AUTO
-          ANGLE FOLLOW
-          BUFFER 3
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _river_font
+				MINDISTANCE 200
+				SIZE _river_lbl_size
+				COLOR _river_lbl_clr
+				OUTLINECOLOR _river_lbl_ol_clr
+				OUTLINEWIDTH _river_lbl_ol_width
+				REPEATDISTANCE 400
+				ENCODING "utf-8"
+				MINFEATURESIZE AUTO
+				ANGLE FOLLOW
+				BUFFER 3
+			END
 #endif
-    END
-    CLASS
-        EXPRESSION "stream"
-        STYLE
-            COLOR _stream_clr
-            WIDTH _stream_width
-        END
+		END
+		CLASS
+			EXPRESSION "stream"
+			STYLE
+				COLOR _stream_clr
+				WIDTH _stream_width
+			END
 #if _display_stream_lbl == 1
-        LABEL
-          TYPE TRUETYPE
-          PARTIALS FALSE
-          FONT _stream_font
-          MINDISTANCE 200
-            REPEATDISTANCE 400
-          SIZE _stream_lbl_size
-          COLOR _stream_lbl_clr
-          OUTLINECOLOR _stream_lbl_ol_clr
-          OUTLINEWIDTH _stream_lbl_ol_width
-          MINFEATURESIZE AUTO
-       ENCODING "utf-8"
-          ANGLE FOLLOW
-          BUFFER 3
-        END
+			LABEL
+				TYPE TRUETYPE
+				PARTIALS FALSE
+				FONT _stream_font
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				SIZE _stream_lbl_size
+				COLOR _stream_lbl_clr
+				OUTLINECOLOR _stream_lbl_ol_clr
+				OUTLINEWIDTH _stream_lbl_ol_width
+				MINFEATURESIZE AUTO
+				ENCODING "utf-8"
+				ANGLE FOLLOW
+				BUFFER 3
+			END
 #endif
-    END
-    CLASS
-        EXPRESSION "canal"
-        STYLE
-            COLOR _canal_clr
-            WIDTH _canal_width
-        END
+		END
+		CLASS
+			EXPRESSION "canal"
+			STYLE
+				COLOR _canal_clr
+				WIDTH _canal_width
+			END
 #if _display_canal_lbl == 1
-        LABEL
-          TYPE TRUETYPE
-          FONT _canal_font
-          MINDISTANCE 200
-            REPEATDISTANCE 400
-          SIZE _canal_lbl_size
-          COLOR _canal_lbl_clr
-       ENCODING "utf-8"
-          OUTLINECOLOR _canal_lbl_ol_clr
-          OUTLINEWIDTH _canal_lbl_ol_width
-          MINFEATURESIZE AUTO
-          ANGLE FOLLOW
-          BUFFER 3
-          PARTIALS FALSE
-        END
+			LABEL
+				TYPE TRUETYPE
+				FONT _canal_font
+				MINDISTANCE 200
+				REPEATDISTANCE 400
+				SIZE _canal_lbl_size
+				COLOR _canal_lbl_clr
+				ENCODING "utf-8"
+				OUTLINECOLOR _canal_lbl_ol_clr
+				OUTLINEWIDTH _canal_lbl_ol_width
+				MINFEATURESIZE AUTO
+				ANGLE FOLLOW
+				BUFFER 3
+				PARTIALS FALSE
+			END
 #endif
-    END
-END
+		END
+	END
 #endif
 #endif

--- a/osmbase.map
+++ b/osmbase.map
@@ -15,44 +15,44 @@
 
 #include STYLEPASTER(THEME)
 MAP
+	FONTSET "fonts.lst"
+	SYMBOLSET "symbols.lst"
+	IMAGETYPE png
+	MAXSIZE 4000
+	SIZE 800 800
+	EXTENT OSM_EXTENT
+	UNITS OSM_UNITS 
+	IMAGECOLOR _ocean_clr0
+	WEB
+		METADATA
+			"ows_enable_request" "*"
+			"wms_srs" "OSM_WMS_SRS"
+			"labelcache_map_edge_buffer" "-10"
+			"wms_title" "OpenStreetMap"
+		END
+	END
 
-FONTSET "fonts.lst"
-SYMBOLSET "symbols.lst"
-IMAGETYPE png
-MAXSIZE 4000
-SIZE 800 800
-EXTENT OSM_EXTENT
-UNITS OSM_UNITS 
-IMAGECOLOR _ocean_clr0
-WEB
-   METADATA
-      "ows_enable_request"   "*"
-      "wms_srs" "OSM_WMS_SRS"
-      "labelcache_map_edge_buffer" "-10"
-      "wms_title" "OpenStreetMap"
-   END
-END
-
-DEBUG _debug
+	DEBUG _debug
 #if _debug > 0 || _layerdebug > 0
-CONFIG "MS_ERRORFILE" "stderr"
+	CONFIG "MS_ERRORFILE" "stderr"
 #endif
 
-CONFIG "PROJ_LIB" _proj_lib
-PROJECTION
-   "init=epsg:OSM_SRID"
-END
+	CONFIG "PROJ_LIB" _proj_lib
 
-OUTPUTFORMAT
-  NAME "png_bw"
-  DRIVER "AGG/PNG"
-  MIMETYPE "image/png;mode=8bit,grayscale"
-  IMAGEMODE RGB
-  EXTENSION "png"
-  TRANSPARENT FALSE
-  FORMATOPTION "PALETTE=grey.txt"
-  FORMATOPTION "PALETTE_FORCE=on"
-END
+	PROJECTION
+		"init=epsg:OSM_SRID"
+	END
+
+	OUTPUTFORMAT
+		NAME "png_bw"
+		DRIVER "AGG/PNG"
+		MIMETYPE "image/png;mode=8bit,grayscale"
+		IMAGEMODE RGB
+		EXTENSION "png"
+		TRANSPARENT FALSE
+		FORMATOPTION "PALETTE=grey.txt"
+		FORMATOPTION "PALETTE_FORCE=on"
+	END
 
 #include LEVELPASTER(THEME,0)
 #include "land.map"
@@ -64,6 +64,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 #include LEVELPASTER(THEME,1)
 #include "land.map"
@@ -75,6 +76,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,2)
@@ -87,6 +89,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,3)
@@ -99,6 +102,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,4)
@@ -111,6 +115,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,5)
@@ -123,6 +128,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,6)
@@ -135,6 +141,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,7)
@@ -147,6 +154,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,8)
@@ -159,6 +167,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,9)
@@ -171,6 +180,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,10)
@@ -183,6 +193,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,11)
@@ -195,6 +206,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,12)
@@ -207,6 +219,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,13)
@@ -219,6 +232,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,14)
@@ -231,6 +245,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,15)
@@ -243,6 +258,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,16)
@@ -255,6 +271,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,17)
@@ -267,6 +284,7 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
 
 #include LEVELPASTER(THEME,18)
@@ -279,12 +297,14 @@ END
 #include "symbols-aeroways.map"
 #include "symbols-amenities.map"
 #include "symbols-stations.map"
+#include "housenumbers.map"
 
-SYMBOL
- name "citycircle"
- type ellipse
- points 1 1 end
- filled true
-END
+
+	SYMBOL
+		NAME "citycircle"
+		TYPE ellipse
+		POINTS 1 1 end
+		FILLED true
+	END
 
 END

--- a/osmtopobase.map
+++ b/osmtopobase.map
@@ -15,43 +15,42 @@
 
 #include STYLEPASTER(THEME)
 MAP
+	FONTSET "fonts.lst"
+	SYMBOLSET "symbols.lst"
+	IMAGETYPE png
+	MAXSIZE 4000
+	SIZE 800 800
+	EXTENT OSM_EXTENT
+		UNITS OSM_UNITS
+	IMAGECOLOR _ocean_clr0
+	WEB
+		METADATA
+			"ows_enable_request"   "*"
+			"wms_srs" "OSM_WMS_SRS"
+			"labelcache_map_edge_buffer" "-10"
+			"wms_title" "osm france"
+		END
+	END
 
-FONTSET "fonts.lst"
-SYMBOLSET "symbols.lst"
-IMAGETYPE png
-MAXSIZE 4000
-SIZE 800 800
-EXTENT OSM_EXTENT
-       UNITS OSM_UNITS
-IMAGECOLOR _ocean_clr0
-WEB
-    METADATA
-        "ows_enable_request"   "*"
-        "wms_srs" "OSM_WMS_SRS"
-        "labelcache_map_edge_buffer" "-10"
-        "wms_title" "osm france"
-    END
-END
-
-DEBUG _debug
+	DEBUG _debug
 #if _debug > 0 || _layerdebug > 0
-CONFIG "MS_ERRORFILE" "stderr"
+	CONFIG "MS_ERRORFILE" "stderr"
 #endif
 
-CONFIG "PROJ_LIB" _proj_lib
-PROJECTION
-    "init=epsg:OSM_SRID"
-END
+	CONFIG "PROJ_LIB" _proj_lib
+	PROJECTION
+		"init=epsg:OSM_SRID"
+	END
 
-OUTPUTFORMAT
-    NAME "png"
-    DRIVER AGG/PNG
-    MIMETYPE "image/png"
-    IMAGEMODE RGBA
-    EXTENSION "png"
-    FORMATOPTION "GAMMA=0.75"
-    FORMATOPTION "COMPRESSION=9"
-END
+	OUTPUTFORMAT
+		NAME "png"
+		DRIVER AGG/PNG
+		MIMETYPE "image/png"
+		IMAGEMODE RGBA
+		EXTENSION "png"
+		FORMATOPTION "GAMMA=0.75"
+		FORMATOPTION "COMPRESSION=9"
+	END
 
 #include LEVELPASTER(THEME,0)
 #include "relief.map"

--- a/places.map
+++ b/places.map
@@ -1,259 +1,258 @@
-
-LAYER
- STATUS ON
- GROUP "default" 
- TYPE POINT
- PROJECTION
-  "init=epsg:OSM_SRID"
- END
- CONNECTIONTYPE postgis
- CONNECTION "OSM_DB_CONNECTION"
+	LAYER
+		STATUS ON
+		GROUP "default" 
+		TYPE POINT
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		CONNECTIONTYPE postgis
+		CONNECTION "OSM_DB_CONNECTION"
 #if OSM_FORCE_POSTGIS_EXTENT == 1
- EXTENT OSM_EXTENT
+		EXTENT OSM_EXTENT
 #endif
- NAME layername(places,_layer_suffix)
- MINSCALEDENOM _minscale
- MAXSCALEDENOM _maxscale
- DATA _places_data
- LABELITEM 'name'
- CLASSITEM 'type'
+		NAME layername(places,_layer_suffix)
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		DATA _places_data
+		LABELITEM 'name'
+		CLASSITEM 'type'
 #if _display_capitals == 1
- CLASS
-  EXPRESSION ('[capital]'='1')
-  LABEL
-   FONT _capital_font
-   TYPE TRUETYPE
-   SIZE _capital_lbl_size
-   ENCODING "utf-8"
-   COLOR _capital_lbl_clr
-   OUTLINECOLOR _capital_lbl_ol_clr
-   OUTLINEWIDTH _capital_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 10
-   PARTIALS FALSE
-   POSITION auto
-   #if _display_capital_symbol == 1
-   STYLE
-    SIZE _capital_size
-    SYMBOL "citycircle"
-    COLOR _capital_clr
-    OUTLINECOLOR _capital_ol_clr
-   END
-   STYLE
-    SIZE _capital_fg_size
-    SYMBOL "citycircle"
-    COLOR _capital_fg_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION ('[capital]'='1')
+			LABEL
+				FONT _capital_font
+				TYPE TRUETYPE
+				SIZE _capital_lbl_size
+				ENCODING "utf-8"
+				COLOR _capital_lbl_clr
+				OUTLINECOLOR _capital_lbl_ol_clr
+				OUTLINEWIDTH _capital_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 10
+				PARTIALS FALSE
+				POSITION auto
+#if _display_capital_symbol == 1
+				STYLE
+					SIZE _capital_size
+					SYMBOL "citycircle"
+					COLOR _capital_clr
+					OUTLINECOLOR _capital_ol_clr
+				END
+				STYLE
+					SIZE _capital_fg_size
+					SYMBOL "citycircle"
+					COLOR _capital_fg_clr
+				END
+#endif
+			END
+		END
 #endif
 #if _display_continents == 1
- CLASS
-  EXPRESSION 'continents'
-  LABEL
-   FONT _continent_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _continent_lbl_size
-   COLOR _continent_lbl_clr
-   OUTLINECOLOR _continent_lbl_ol_clr
-   OUTLINEWIDTH _continent_lbl_ol_width
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION cc
-  END
- END
+		CLASS
+			EXPRESSION 'continents'
+			LABEL
+				FONT _continent_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _continent_lbl_size
+				COLOR _continent_lbl_clr
+				OUTLINECOLOR _continent_lbl_ol_clr
+				OUTLINEWIDTH _continent_lbl_ol_width
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION cc
+			END
+		END
 #endif
 #if _display_countries == 1
- CLASS
-  EXPRESSION 'country'
-  LABEL
-   FONT _country_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _country_lbl_size
-   COLOR _country_lbl_clr
-   OUTLINECOLOR _country_lbl_ol_clr
-   OUTLINEWIDTH _country_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION cc
-  END
- END
+		CLASS
+			EXPRESSION 'country'
+			LABEL
+				FONT _country_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _country_lbl_size
+				COLOR _country_lbl_clr
+				OUTLINECOLOR _country_lbl_ol_clr
+				OUTLINEWIDTH _country_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION cc
+			END
+		END
 #endif
 #if _display_cities == 1
- CLASS
-  EXPRESSION 'city'
-  LABEL
-   FONT _city_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _city_lbl_size
-   COLOR _city_lbl_clr
-   OUTLINECOLOR _city_lbl_ol_clr
-   OUTLINEWIDTH _city_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION auto
-   #if _display_city_symbol == 1
-   STYLE
-    SIZE _city_size
-    SYMBOL "citycircle"
-    COLOR _city_clr
-    OUTLINECOLOR _city_ol_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'city'
+			LABEL
+				FONT _city_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _city_lbl_size
+				COLOR _city_lbl_clr
+				OUTLINECOLOR _city_lbl_ol_clr
+				OUTLINEWIDTH _city_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION auto
+#if _display_city_symbol == 1
+				STYLE
+					SIZE _city_size
+					SYMBOL "citycircle"
+					COLOR _city_clr
+					OUTLINECOLOR _city_ol_clr
+				END
+#endif
+			END
+		END
 #endif
 #if _display_towns == 1
- CLASS
-  EXPRESSION 'town'
-  LABEL
-   FONT _town_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _town_lbl_size
-   COLOR _town_lbl_clr
-   OUTLINECOLOR _town_lbl_ol_clr
-   OUTLINEWIDTH _town_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   PARTIALS FALSE
-   POSITION AUTO
-   BUFFER 4
-   POSITION auto
-   #if _display_town_symbol == 1
-   STYLE
-    SIZE _town_size
-    SYMBOL "citycircle"
-    COLOR _town_clr
-    OUTLINECOLOR _town_ol_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'town'
+			LABEL
+				FONT _town_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _town_lbl_size
+				COLOR _town_lbl_clr
+				OUTLINECOLOR _town_lbl_ol_clr
+				OUTLINEWIDTH _town_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				PARTIALS FALSE
+				POSITION AUTO
+				BUFFER 4
+				POSITION auto
+#if _display_town_symbol == 1
+				STYLE
+					SIZE _town_size
+					SYMBOL "citycircle"
+					COLOR _town_clr
+					OUTLINECOLOR _town_ol_clr
+				END
+#endif
+			END
+		END
 #endif
 #if _display_suburbs == 1
- CLASS
-  EXPRESSION 'suburb'
-  LABEL
-   FONT _suburb_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _suburb_lbl_size
-   COLOR _suburb_lbl_clr
-   OUTLINECOLOR _suburb_lbl_ol_clr
-   OUTLINEWIDTH _suburb_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION AUTO
-   #if _display_suburb_symbol == 1
-   STYLE
-       SIZE _suburb_size
-       SYMBOL "citycircle"
-       COLOR _suburb_clr
-       OUTLINECOLOR _suburb_ol_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'suburb'
+			LABEL
+				FONT _suburb_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _suburb_lbl_size
+				COLOR _suburb_lbl_clr
+				OUTLINECOLOR _suburb_lbl_ol_clr
+				OUTLINEWIDTH _suburb_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION AUTO
+#if _display_suburb_symbol == 1
+				STYLE
+					SIZE _suburb_size
+					SYMBOL "citycircle"
+					COLOR _suburb_clr
+					OUTLINECOLOR _suburb_ol_clr
+				END
+#endif
+			END
+		END
 #endif
 #if _display_villages == 1
- CLASS
-  EXPRESSION 'village'
-  LABEL
-   FONT _village_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _village_lbl_size
-   COLOR _village_lbl_clr
-   OUTLINECOLOR _village_lbl_ol_clr
-   OUTLINEWIDTH _village_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   PARTIALS FALSE
-   BUFFER 4
-   POSITION AUTO
-   #if _display_village_symbol == 1
-   STYLE
-       SYMBOL "citycircle"
-       COLOR _village_clr
-       OUTLINECOLOR _village_ol_clr
-       SIZE _village_size
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'village'
+			LABEL
+				FONT _village_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _village_lbl_size
+				COLOR _village_lbl_clr
+				OUTLINECOLOR _village_lbl_ol_clr
+				OUTLINEWIDTH _village_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				PARTIALS FALSE
+				BUFFER 4
+				POSITION AUTO
+#if _display_village_symbol == 1
+				STYLE
+					SYMBOL "citycircle"
+					COLOR _village_clr
+					OUTLINECOLOR _village_ol_clr
+					SIZE _village_size
+				END
+#endif
+			END
+		END
 #endif
 #if _display_hamlets == 1
- CLASS
-  EXPRESSION 'hamlet'
-  LABEL
-   FONT _hamlet_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _hamlet_lbl_size
-   COLOR _hamlet_lbl_clr
-   OUTLINECOLOR _hamlet_lbl_ol_clr
-   OUTLINEWIDTH _hamlet_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION AUTO
-   #if _display_hamlet_symbol == 1
-   STYLE
-       SIZE _hamlet_size
-       SYMBOL "citycircle"
-       COLOR _hamlet_clr
-       OUTLINECOLOR _hamlet_ol_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'hamlet'
+			LABEL
+				FONT _hamlet_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _hamlet_lbl_size
+				COLOR _hamlet_lbl_clr
+				OUTLINECOLOR _hamlet_lbl_ol_clr
+				OUTLINEWIDTH _hamlet_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION AUTO
+#if _display_hamlet_symbol == 1
+				STYLE
+					SIZE _hamlet_size
+					SYMBOL "citycircle"
+					COLOR _hamlet_clr
+					OUTLINECOLOR _hamlet_ol_clr
+				END
+#endif
+			END
+		END
 #endif
 #if _display_localities == 1
- CLASS
-  EXPRESSION 'locality'
-  LABEL
-   FONT _locality_font
-   TYPE TRUETYPE
-   ENCODING "utf-8"
-   SIZE _locality_lbl_size
-   COLOR _locality_lbl_clr
-   OUTLINECOLOR _locality_lbl_ol_clr
-   OUTLINEWIDTH _locality_lbl_ol_width
-   WRAP ' '
-   MAXLENGTH 8
-   ALIGN CENTER
-   BUFFER 4
-   PARTIALS FALSE
-   POSITION AUTO
-   #if _display_locality_symbol == 1
-   STYLE
-       SIZE _locality_size
-       SYMBOL "citycircle"
-       COLOR _locality_clr
-       OUTLINECOLOR _locality_ol_clr
-   END
-   #endif
-  END
- END
+		CLASS
+			EXPRESSION 'locality'
+			LABEL
+				FONT _locality_font
+				TYPE TRUETYPE
+				ENCODING "utf-8"
+				SIZE _locality_lbl_size
+				COLOR _locality_lbl_clr
+				OUTLINECOLOR _locality_lbl_ol_clr
+				OUTLINEWIDTH _locality_lbl_ol_width
+				WRAP ' '
+				MAXLENGTH 8
+				ALIGN CENTER
+				BUFFER 4
+				PARTIALS FALSE
+				POSITION AUTO
+#if _display_locality_symbol == 1
+				STYLE
+					SIZE _locality_size
+					SYMBOL "citycircle"
+					COLOR _locality_clr
+					OUTLINECOLOR _locality_ol_clr
+				END
 #endif
-END
+			END
+		END
+#endif
+	END

--- a/symbols-aeroways.map
+++ b/symbols-aeroways.map
@@ -1,64 +1,70 @@
 #if _display_symbols == 1
-LAYER
-    GROUP "default"
-    STATUS ON
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE POINT
-    NAME layername(symairport,_layer_suffix)
-    DATA _symairport_data
-    CLASSITEM "name"
-#if _display_symairways == 1
-    CLASS
-      EXPRESSION /^Aéroport.*$/
-      LABEL
-#if _display_symairways_lbl == 1
-            SIZE _symairport_lbl_size
-            COLOR _symairport_lbl_clr
-            TEXT _symairport_lbl_txt
-            OUTLINECOLOR _sym_lbl_ol_clr
-            OUTLINEWIDTH _sym_lbl_ol_width
-            OFFSET 0 2
-            POSITION lc
-            FONT _symairport_lbl_font
-            TYPE truetype
-            MAXLENGTH 0
-            ALIGN CENTER
-            WRAP ' '
-            FORCE TRUE
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE POINT
+#if OSM_FORCE_POSTGIS_EXTENT == 1
+		EXTENT OSM_EXTENT
 #endif
-        STYLE
-          SYMBOL _symairport_symbol
-        END
-      END
-  END
+		NAME layername(symairport,_layer_suffix)
+		DATA _symairport_data
+		CLASSITEM "name"
+#if _display_symairways == 1
+		CLASS
+			EXPRESSION /^Aéroport.*$/
+			LABEL
+#if _display_symairways_lbl == 1
+				SIZE _symairport_lbl_size
+				COLOR _symairport_lbl_clr
+				TEXT _symairport_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 2
+				POSITION lc
+				FONT _symairport_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				ALIGN CENTER
+				WRAP ' '
+				FORCE TRUE
+#endif
+				STYLE
+					SYMBOL _symairport_symbol
+				END
+			END
+		END
 #endif
 #if _display_symaerodrome == 1
-  CLASS
-      EXPRESSION /^[Aérodrome|Altisurface].*$/
-      LABEL
+		CLASS
+			EXPRESSION /^[Aérodrome|Altisurface].*$/
+			LABEL
 #if _display_symaerodrome_lbl == 1
-            SIZE _symaerodrome_lbl_size
-            COLOR _symaerodrome_lbl_clr
-            TEXT _symaerodrome_lbl_txt
-            OUTLINECOLOR _sym_lbl_ol_clr
-            OUTLINEWIDTH _sym_lbl_ol_width
-            OFFSET 0 2
-            POSITION lc
-            FONT _symaerodrome_lbl_font
-            TYPE truetype
-            MAXLENGTH 0
-            ALIGN CENTER
-            WRAP ' '
-            FORCE TRUE
+				SIZE _symaerodrome_lbl_size
+				COLOR _symaerodrome_lbl_clr
+				TEXT _symaerodrome_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 2
+				POSITION lc
+				FONT _symaerodrome_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				ALIGN CENTER
+				WRAP ' '
+				FORCE TRUE
 #endif
-        STYLE
-          SYMBOL _symaerodrome_symbol
-        END
-      END
-    END
+				STYLE
+					SYMBOL _symaerodrome_symbol
+				END
+			END
+		END
 #endif
-END
+	END
 #endif

--- a/symbols-amenities.map
+++ b/symbols-amenities.map
@@ -1,2143 +1,2148 @@
 #if _display_symamenities == 1
-  LAYER
-    GROUP "default"
-    STATUS ON
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE POINT
-    NAME layername(symamenities,_layer_suffix)
-    DATA _symamenities_data
-
-    /**************************** symbols displayed at z11 ******************************************************/
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE POINT
+		NAME layername(symamenities,_layer_suffix)
+		DATA _symamenities_data
+#if OSM_FORCE_POSTGIS_EXTENT == 1
+		EXTENT OSM_EXTENT
+#endif
+		/**************************** symbols displayed at z11 ******************************************************/
 #if _display_symbols_z11 == 1
-    CLASS
-     EXPRESSION (('[feature]' = 'natural_volcano') OR ('[feature]' = 'natural_peak'))
-      LABEL
+		CLASS
+			EXPRESSION (('[feature]' = 'natural_volcano') OR ('[feature]' = 'natural_peak'))
+			LABEL
 #if _display_peak_lbl == 1
-        partials false
-        SIZE _sym_lbl_size
-        COLOR _sympeak_lbl_clr
-        TEXT _sym_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 0
-        POSITION lc
-        FONT _sympeak_lbl_font
-        TYPE TRUETYPE
-        POSITION lc
-        WRAP ' '
-        MAXLENGTH 6
-        ALIGN CENTER
-        MINFEATURESIZE AUTO
-        ALIGN CENTER
+				partials false
+				SIZE _sym_lbl_size
+				COLOR _sympeak_lbl_clr
+				TEXT _sym_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 0
+				POSITION lc
+				FONT _sympeak_lbl_font
+				TYPE TRUETYPE
+				POSITION lc
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				ALIGN CENTER
 #endif
-        STYLE
-          SYMBOL "symbols-peak-svg"
-        END
-      END
-    END
+				STYLE
+					SYMBOL "symbols-peak-svg"
+				END
+			END
+		END
 #endif
-    /**************************** symbols displayed at z12 ******************************************************/
+		/**************************** symbols displayed at z12 ******************************************************/
 
-    /**************************** symbols displayed at z13 ******************************************************/
+		/**************************** symbols displayed at z13 ******************************************************/
 #if _display_symbols_z13 == 1
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_alpine_hut')
-      LABEL
-        STYLE
-          SYMBOL "symbols-alpinehut-p-16-png"
-        END
-      END
-    END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_alpine_hut')
+			LABEL
+				STYLE
+					SYMBOL "symbols-alpinehut-p-16-png"
+				END
+			END
+		END
 #endif
 
-    /**************************** symbols displayed at z14 ******************************************************/
+/**************************** symbols displayed at z14 ******************************************************/
 #if _display_symbols_z14 == 1
-    CLASS
-     EXPRESSION ('[feature]' = 'natural_spring')
-      LABEL
-        STYLE
-          SYMBOL "symbols-spring-svg"
-        END
-      END
-    END
+		CLASS
+			EXPRESSION ('[feature]' = 'natural_spring')
+			LABEL
+				STYLE
+					SYMBOL "symbols-spring-svg"
+				END
+			END
+		END
 #endif
 
-    /**************************** symbols displayed at z15 ******************************************************/
+/**************************** symbols displayed at z15 ******************************************************/
 #if _display_symbols_z15 == 1
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_hospital')
-      LABEL
-        partials false
-        SIZE _sym_lbl_size
-        COLOR _symhospital_lbl_clr
-        TEXT _sym_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 0
-        POSITION lc
-        FONT _symhospital_lbl_font
-        TYPE TRUETYPE
-        POSITION lc
-        WRAP ' '
-        MAXLENGTH 6
-        ALIGN CENTER
-        MINFEATURESIZE AUTO
-        ALIGN CENTER
-         STYLE
-          SYMBOL _symhospital_symbol
-         end
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'power_generator') AND ('[generator_source]' = 'wind') AND ('[power_source]' = 'wind'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-power-wind-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'power_generator') AND ('[power_source]' = 'wind'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-power-wind-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'power_generator') AND ('[generator_source]' = 'wind'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-power-wind-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'natural_cave_entrance')
-      LABEL
-        STYLE
-          SYMBOL "symbols-cave-14-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'natural_saddle')
-      LABEL
-        STYLE
-          SYMBOL "symbols-saddle-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'man_made_lighthouse')
-      LABEL
-        STYLE
-          SYMBOL "symbols-lighthouse-16-svg"
-        END
-      END
-    END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_hospital')
+			LABEL
+				partials false
+				SIZE _sym_lbl_size
+				COLOR _symhospital_lbl_clr
+				TEXT _sym_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 0
+				POSITION lc
+				FONT _symhospital_lbl_font
+				TYPE TRUETYPE
+				POSITION lc
+				WRAP ' '
+				MAXLENGTH 6
+				ALIGN CENTER
+				MINFEATURESIZE AUTO
+				ALIGN CENTER
+				STYLE
+					SYMBOL _symhospital_symbol
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'power_generator') AND ('[generator_source]' = 'wind') AND ('[power_source]' = 'wind'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-power-wind-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'power_generator') AND ('[power_source]' = 'wind'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-power-wind-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'power_generator') AND ('[generator_source]' = 'wind'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-power-wind-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'natural_cave_entrance')
+			LABEL
+				STYLE
+					SYMBOL "symbols-cave-14-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'natural_saddle')
+			LABEL
+				STYLE
+					SYMBOL "symbols-saddle-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'man_made_lighthouse')
+			LABEL
+				STYLE
+					SYMBOL "symbols-lighthouse-16-svg"
+				END
+			END
+		END
 #endif
 
-    /**************************** symbols displayed at z16 ******************************************************/
+		/**************************** symbols displayed at z16 ******************************************************/
 #if _display_symbols_z16 == 1
-    CLASS
-     EXPRESSION (('[denomination]' = 'jehovahs_witness') AND ('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'christian'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-place-of-worship-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'taoist'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-taoist-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'shinto'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-shintoist-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'buddhist'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-buddhist-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'hindu'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-hinduist-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'jewish'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-jewish-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'sikh'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-sikhist-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'muslim'))
-      LABEL
-        STYLE
-          SYMBOL "symbols-muslim-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'christian'))
-        STYLE
-          SYMBOL "symbols-christian-16-svg"
-        END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_place_of_worship')
-      LABEL
-        STYLE
-          SYMBOL "symbols-place-of-worship-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_hunting_stand')
-      LABEL
-        STYLE
-          SYMBOL "symbols-hunting-stand-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'man_made_windmill')
-      LABEL
-        STYLE
-          SYMBOL "symbols-windmill-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'aeroway_helipad')
-      LABEL
-        STYLE
-          SYMBOL "symbols-helipad-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_picnic_site')
-      LABEL
-        STYLE
-          SYMBOL "symbols-picnic-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'shop_department_store')
-      LABEL
-        partials false
-        SIZE 7.4
-        COLOR "#9C399C"
-        TEXT '[name]'
-        OUTLINECOLOR "#ffffff99"
-        OUTLINEWIDTH 2.3814773980154356
-        OFFSET 0 2
-        POSITION lc
-        FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
-        TYPE truetype
-        MAXLENGTH 0
-        WRAP " "
-        ALIGN CENTER
-        STYLE
-          SYMBOL "symbols-department-store-p-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'shop_supermarket')
-      LABEL
-        partials false
-        SIZE 7.4
-        COLOR "#9C399C"
-        TEXT '[name]'
-        OUTLINECOLOR "#ffffff99"
-        OUTLINEWIDTH 2.3814773980154356
-        OFFSET 0 2
-        POSITION lc
-        FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
-        TYPE truetype
-        MAXLENGTH 0
-        WRAP " "
-        ALIGN CENTER
-        STYLE
-          SYMBOL "symbols-shop-supermarket-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'historic_archaeological_site')
-      LABEL
-        STYLE
-          SYMBOL "symbols-archaeological-site-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'historic_monument')
-      LABEL
-        STYLE
-          SYMBOL "symbols-monument-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'man_made_obelisk')
-      LABEL
-        STYLE
-          SYMBOL "symbols-monument-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_viewpoint')
-      LABEL
-        STYLE
-          SYMBOL "symbols-viewpoint-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_theatre')
-        STYLE
-          SYMBOL "symbols-theatre-16-svg"
-        END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_police')
-      LABEL
-        STYLE
-          SYMBOL "symbols-police-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_place_of_worship')
-      LABEL
-        STYLE
-          SYMBOL "symbols-place-of-worship-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_clinic')
-      LABEL
-        STYLE
-          SYMBOL "symbols-doctors-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_museum')
-      LABEL
-        STYLE
-          SYMBOL "symbols-museum-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_townhall')
-      LABEL
-        STYLE
-          SYMBOL "symbols-town-hall-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_courthouse')
-      LABEL
-        STYLE
-          SYMBOL "symbols-courthouse-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_library')
-      LABEL
-        STYLE
-          SYMBOL "symbols-library-14-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_fire_station')
-      LABEL
-        STYLE
-          SYMBOL "symbols-firestation-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_cinema')
-      LABEL
-        STYLE
-          SYMBOL "symbols-cinema-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_caravan_site')
-      LABEL
-        STYLE
-          SYMBOL "symbols-caravan-park-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'highway_ford')
-      LABEL
-        STYLE
-          SYMBOL "symbols-ford-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'tourism_camp_site')
-      LABEL
-        STYLE
-          SYMBOL "symbols-camping-16-svg"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_shelter')
-      LABEL
-        STYLE
-          SYMBOL "symbols-shelter-14-svg"
-        END
-      END
-    END
+		CLASS
+			EXPRESSION (('[denomination]' = 'jehovahs_witness') AND ('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'christian'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-place-of-worship-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'taoist'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-taoist-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'shinto'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-shintoist-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'buddhist'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-buddhist-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'hindu'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-hinduist-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'jewish'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-jewish-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'sikh'))
+				LABEL
+					STYLE
+						SYMBOL "symbols-sikhist-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'muslim'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-muslim-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_place_of_worship') AND ('[religion]' = 'christian'))
+			STYLE
+				SYMBOL "symbols-christian-16-svg"
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_place_of_worship')
+			LABEL
+				STYLE
+					SYMBOL "symbols-place-of-worship-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_hunting_stand')
+			LABEL
+				STYLE
+					SYMBOL "symbols-hunting-stand-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'man_made_windmill')
+			LABEL
+				STYLE
+					SYMBOL "symbols-windmill-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'aeroway_helipad')
+			LABEL
+				STYLE
+					SYMBOL "symbols-helipad-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_picnic_site')
+			LABEL
+				STYLE
+					SYMBOL "symbols-picnic-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'shop_department_store')
+			LABEL
+				partials false
+				SIZE 7.4
+				COLOR "#9C399C"
+				TEXT '[name]'
+				OUTLINECOLOR "#ffffff99"
+				OUTLINEWIDTH 2.3814773980154356
+				OFFSET 0 2
+				POSITION lc
+				FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
+				TYPE truetype
+				MAXLENGTH 0
+				WRAP " "
+				ALIGN CENTER
+				STYLE
+					SYMBOL "symbols-department-store-p-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'shop_supermarket')
+			LABEL
+				partials false
+				SIZE 7.4
+				COLOR "#9C399C"
+				TEXT '[name]'
+				OUTLINECOLOR "#ffffff99"
+				OUTLINEWIDTH 2.3814773980154356
+				OFFSET 0 2
+				POSITION lc
+				FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
+				TYPE truetype
+				MAXLENGTH 0
+				WRAP " "
+				ALIGN CENTER
+				STYLE
+					SYMBOL "symbols-shop-supermarket-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'historic_archaeological_site')
+			LABEL
+				STYLE
+					SYMBOL "symbols-archaeological-site-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'historic_monument')
+			LABEL
+				STYLE
+					SYMBOL "symbols-monument-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'man_made_obelisk')
+			LABEL
+				STYLE
+					SYMBOL "symbols-monument-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_viewpoint')
+			LABEL
+				STYLE
+					SYMBOL "symbols-viewpoint-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_theatre')
+			STYLE
+				SYMBOL "symbols-theatre-16-svg"
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_police')
+			LABEL
+				STYLE
+					SYMBOL "symbols-police-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_place_of_worship')
+			LABEL
+				STYLE
+					SYMBOL "symbols-place-of-worship-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_clinic')
+			LABEL
+				STYLE
+					SYMBOL "symbols-doctors-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_museum')
+			LABEL
+				STYLE
+					SYMBOL "symbols-museum-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_townhall')
+			LABEL
+				STYLE
+					SYMBOL "symbols-town-hall-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_courthouse')
+			LABEL
+				STYLE
+					SYMBOL "symbols-courthouse-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_library')
+			LABEL
+				STYLE
+					SYMBOL "symbols-library-14-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_fire_station')
+			LABEL
+				STYLE
+					SYMBOL "symbols-firestation-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_cinema')
+			LABEL
+				STYLE
+					SYMBOL "symbols-cinema-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_caravan_site')
+			LABEL
+				STYLE
+					SYMBOL "symbols-caravan-park-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'highway_ford')
+			LABEL
+				STYLE
+					SYMBOL "symbols-ford-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'tourism_camp_site')
+			LABEL
+				STYLE
+					SYMBOL "symbols-camping-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_shelter')
+			LABEL
+				STYLE
+					SYMBOL "symbols-shelter-14-svg"
+				END
+			END
+		END
 #endif
 
-    /**************************** symbols displayed at z17 ***************************************************************************/
+		/**************************** symbols displayed at z17 ***************************************************************************/
 #if _display_symbols_z17 == 1
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_marketplace')
-      LABEL
-        partials false
-        SIZE 7.4
-        COLOR "#9C399C"
-        TEXT '[name]'
-        OUTLINECOLOR "#ffffff99"
-        OUTLINEWIDTH 2.3814773980154356
-        OFFSET 0 2
-        POSITION lc
-        FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
-        TYPE truetype
-        MAXLENGTH 0
-        WRAP " "
-        ALIGN CENTER
-        FORCE true
-        STYLE
-          SYMBOL "symbols-shop-marketplace"
-        END
-      END
-    END
-    CLASS
-     EXPRESSION ('[feature]' = 'amenity_pharmacy')
-      LABEL
-      FORCE true
-        STYLE
-          SYMBOL _sympharmacy_symbol
-        END
-      END
-    END
-     CLASS
-       EXPRESSION ( ('[feature]' = 'amenity_motorcycle_parking') )
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-         OPACITY 0.33
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL _symmotorparking_symbol
-         #endif
-         END
-       END
-     END
-     CLASS
-       EXPRESSION ( ('[feature]' = 'shop_interior_decoration') )
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-          OPACITY 0.33
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-interior-decoration-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-       EXPRESSION (('[feature]' = 'amenity_bicycle_parking') )
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-         OPACITY 0.33
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL _symbikeparking_symbol
-         #endif
-         END
-       END
-     END
-     CLASS
-       EXPRESSION (('[access]' = 'yes') AND ('[feature]' = 'amenity_parking') )
-       LABEL
-         STYLE
-           SYMBOL _symparking_symbol
-         END
-       END
-     END
-     CLASS
-      EXPRESSION (('[access]' != '') AND ('[access]' != 'yes') AND ('[feature]' = 'leisure_playground'))
-       LABEL
-       FORCE true
-       STYLE
-         OPACITY 0.33
-           SYMBOL "symbols-playground-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION (('[access]' != '') AND ('[access]' != 'yes') AND ('[feature]' = 'amenity_recycling'))
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-         OPACITY 0.33
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-recycling-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_slipway')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-transport-slipway-p-20-png"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_picnic_table')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-picnic-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_miniature_golf')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-miniature-golf-p-20-png"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_playground')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-playground-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_dog_park')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-shop-pet-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'leisure_water_park')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-water-park-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_variety_store')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-variety-store-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_tea')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-tea-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_tobacco')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-tobacco-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_stationery')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-stationery-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_sports')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-sports-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_travel_agency')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-travel-agency-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_toys')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-toys-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_jewellery')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-jewelry-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_jewelry')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-jewelry-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_newsagent')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-newsagent-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_kiosk')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-newsagent-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_musical_instrument')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-musical-instrument-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_motorcycle')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-motorcycle-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_mobile_phone')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-mobile-phone-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_furniture')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-furniture-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_outdoor')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-outdoor-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_optician')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-optician-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_wine')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-alcohol-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_alcohol')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-alcohol-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_electronics')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-electronics-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_gift')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-gift-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_shoes')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-shoes-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_photography')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-photo-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_photo_studio')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-photo-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_photo')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-photo-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_pet')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-pet-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_bicycle')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-bicycle-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_car_repair')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shopping-car-repair-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_car_parts')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-car-parts-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_car')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-car-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_ice_cream')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-ice-cream-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_hifi')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-hifi-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_hairdresser')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-hairdresser-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_farm')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-greengrocer-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_greengrocer')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-greengrocer-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_garden_centre')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-garden-centre-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_florist')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-florist-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_seafood')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-seafood-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_fishmonger')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-seafood-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_laundry')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-laundry-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_dry_cleaning')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-laundry-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_hardware')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-diy-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_doityourself')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-diy-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_deli')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-deli-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_perfumery')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-perfumery-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_cosmetics')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-perfumery-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_copyshop')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-copyshop-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_confectionery')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-confectionery-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_convenience')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-convenience-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_computer')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-computer-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_fashion')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-clothes-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_clothes')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-clothes-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_chemist')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-chemist-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_butcher')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-butcher-png"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_books')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-library-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_beverages')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-beverages-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_beauty')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-beauty-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_bakery')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-shop-bakery-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'shop_bag')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 154 30 156
-          #else
-           SYMBOL "symbols-bag-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION (('[feature]' = 'shop_art') OR ('[feature]' = 'shop_gallery'))
-       LABEL
-         STYLE
-           SYMBOL "symbols-art-14-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'historic_memorial')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-tourist-memorial-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'man_made_water_tower')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-water-tower-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_prison')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-prison-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_drinking_water')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-drinking-water-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_toilets')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-toilets-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_emergency_phone')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-emergency-phone-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_telephone')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-telephone-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_fast_food')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-fast-food-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_food_court')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-restaurant-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_restaurant')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-restaurant-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_recycling')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-recycling-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_biergarten')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-biergarten-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_pub')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-pub-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_post_office')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-post-office-14-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_post_box')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-post-box-12-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'historic_wayside_cross')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-christian-9-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'man_made_cross')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-christian-9-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_veterinary')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-veterinary-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_dentist')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-dentist-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_doctors')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-doctors-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'man_made_mast')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-communications-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_social_facility')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-social-facility-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_community_centre')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-community-centre-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_embassy')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-embassy-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_information')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-information-12-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_ice_cream')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-ice-cream-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_motel')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-motel-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_hotel')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-hotel-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_hostel')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-hostel-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_guest_house')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-guest-house-p-16-png"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_fuel')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-fuel-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_charging_station')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-charging-station-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_nightclub')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-nightclub-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_chalet')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-chalet-p-16-png"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_car_wash')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-car-wash-14-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_car_rental')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-rental-car-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'tourism_artwork')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-artwork-14-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_cafe')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-cafe-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'highway_traffic_signals')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-traffic-light-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_taxi')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-taxi-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_bicycle_rental')
-       LABEL
-       FORCE true
-         STYLE
-           SYMBOL "symbols-rental-bicycle-16-svg"
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_bar')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-bar-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_bank')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-bank-16-svg"
-         #endif
-         END
-       END
-     END
-     CLASS
-      EXPRESSION ('[feature]' = 'amenity_atm')
-       LABEL
-       FORCE true
-         STYLE
-         #if _display_symbols_circle == 1
-           SYMBOL "shopcircle"
-           SIZE 4
-           color 185 96 5
-          #else
-           SYMBOL "symbols-atm-16-svg"
-         #endif
-         END
-       END
-     END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_marketplace')
+			LABEL
+				partials false
+				SIZE 7.4
+				COLOR "#9C399C"
+				TEXT '[name]'
+				OUTLINECOLOR "#ffffff99"
+				OUTLINEWIDTH 2.3814773980154356
+				OFFSET 0 2
+				POSITION lc
+				FONT "NotoSansUIRegular,NotoSansSymbolsRegular,NotoEmojiRegular,DejaVuSansBook"
+				TYPE truetype
+				MAXLENGTH 0
+				WRAP " "
+				ALIGN CENTER
+				FORCE true
+				STYLE
+					SYMBOL "symbols-shop-marketplace"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ('[feature]' = 'amenity_pharmacy')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL _sympharmacy_symbol
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ( ('[feature]' = 'amenity_motorcycle_parking') )
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					OPACITY 0.33
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL _symmotorparking_symbol
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION ( ('[feature]' = 'shop_interior_decoration') )
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					OPACITY 0.33
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-interior-decoration-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[feature]' = 'amenity_bicycle_parking') )
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					OPACITY 0.33
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL _symbikeparking_symbol
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION (('[access]' = 'yes') AND ('[feature]' = 'amenity_parking') )
+			LABEL
+				STYLE
+					SYMBOL _symparking_symbol
+				END
+			END
+		END
+		CLASS
+			EXPRESSION(('[access]' != '') AND ('[access]' != 'yes') AND ('[feature]' = 'leisure_playground'))
+			LABEL
+				FORCE true
+				STYLE
+					OPACITY 0.33
+					SYMBOL "symbols-playground-16-svg"
+					END
+				END
+		END
+		CLASS
+			EXPRESSION(('[access]' != '') AND ('[access]' != 'yes') AND ('[feature]' = 'amenity_recycling'))
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					OPACITY 0.33
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-recycling-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_slipway')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-transport-slipway-p-20-png"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_picnic_table')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-picnic-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_miniature_golf')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-miniature-golf-p-20-png"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_playground')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-playground-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_dog_park')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-shop-pet-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'leisure_water_park')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-water-park-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_variety_store')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-variety-store-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_tea')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-tea-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_tobacco')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-tobacco-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_stationery')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-stationery-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_sports')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-sports-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_travel_agency')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-travel-agency-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_toys')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-toys-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_jewellery')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-jewelry-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_jewelry')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-jewelry-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_newsagent')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-newsagent-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_kiosk')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-newsagent-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_musical_instrument')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-musical-instrument-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_motorcycle')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-motorcycle-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_mobile_phone')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-mobile-phone-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_furniture')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-furniture-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_outdoor')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-outdoor-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_optician')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-optician-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_wine')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-alcohol-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_alcohol')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-alcohol-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_electronics')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-electronics-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_gift')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-gift-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_shoes')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-shoes-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_photography')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-photo-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_photo_studio')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-photo-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_photo')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-photo-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_pet')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-pet-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_bicycle')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-bicycle-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_car_repair')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shopping-car-repair-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_car_parts')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-car-parts-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_car')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-car-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_ice_cream')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-ice-cream-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_hifi')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-hifi-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_hairdresser')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-hairdresser-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_farm')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-greengrocer-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_greengrocer')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-greengrocer-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_garden_centre')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-garden-centre-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_florist')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-florist-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_seafood')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-seafood-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_fishmonger')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-seafood-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_laundry')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-laundry-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_dry_cleaning')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-laundry-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_hardware')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-diy-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_doityourself')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-diy-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_deli')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-deli-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_perfumery')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-perfumery-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_cosmetics')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-perfumery-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_copyshop')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-copyshop-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_confectionery')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-confectionery-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_convenience')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-convenience-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_computer')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-computer-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_fashion')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-clothes-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_clothes')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-clothes-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_chemist')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-chemist-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_butcher')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-butcher-png"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_books')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-library-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_beverages')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-beverages-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_beauty')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-beauty-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_bakery')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-shop-bakery-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'shop_bag')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 154 30 156
+#else
+					SYMBOL "symbols-bag-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION(('[feature]' = 'shop_art') OR ('[feature]' = 'shop_gallery'))
+			LABEL
+				STYLE
+					SYMBOL "symbols-art-14-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'historic_memorial')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-tourist-memorial-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'man_made_water_tower')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-water-tower-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_prison')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-prison-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_drinking_water')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-drinking-water-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_toilets')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-toilets-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_emergency_phone')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-emergency-phone-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_telephone')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-telephone-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_fast_food')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-fast-food-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_food_court')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-restaurant-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_restaurant')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-restaurant-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_recycling')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-recycling-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_biergarten')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-biergarten-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_pub')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-pub-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_post_office')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-post-office-14-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_post_box')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-post-box-12-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'historic_wayside_cross')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-christian-9-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'man_made_cross')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-christian-9-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_veterinary')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-veterinary-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_dentist')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-dentist-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_doctors')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-doctors-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'man_made_mast')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-communications-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_social_facility')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-social-facility-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_community_centre')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-community-centre-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_embassy')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-embassy-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_information')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-information-12-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_ice_cream')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-ice-cream-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_motel')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-motel-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_hotel')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-hotel-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_hostel')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-hostel-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_guest_house')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-guest-house-p-16-png"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_fuel')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-fuel-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_charging_station')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-charging-station-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_nightclub')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-nightclub-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_chalet')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-chalet-p-16-png"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_car_wash')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-car-wash-14-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_car_rental')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-rental-car-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'tourism_artwork')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-artwork-14-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_cafe')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-cafe-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'highway_traffic_signals')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-traffic-light-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_taxi')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-taxi-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_bicycle_rental')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-rental-bicycle-16-svg"
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_bar')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-bar-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_bank')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-bank-16-svg"
+#endif
+				END
+			END
+		END
+		CLASS
+			EXPRESSION('[feature]' = 'amenity_atm')
+			LABEL
+				FORCE true
+				STYLE
+#if _display_symbols_circle == 1
+					SYMBOL "shopcircle"
+					SIZE 4
+					COLOR 185 96 5
+#else
+					SYMBOL "symbols-atm-16-svg"
+#endif
+				END
+			END
+		END
 #endif
 
-    /**************************** symbols displayed at z18 ***************************************************************************/
+		/**************************** symbols displayed at z18 ***************************************************************************/
 #if _display_symbols_z17 == 1
-    CLASS
-     EXPRESSION ('[feature]' = 'highway_elevator')
-      LABEL
-      FORCE true
-        STYLE
-          SYMBOL "symbols-elevator-12-svg"
-        END
-      END
-    END
+		CLASS
+			EXPRESSION ('[feature]' = 'highway_elevator')
+			LABEL
+				FORCE true
+				STYLE
+					SYMBOL "symbols-elevator-12-svg"
+				END
+			END
+		END
 #endif
-  END
+	END
 #endif

--- a/symbols-stations.map
+++ b/symbols-stations.map
@@ -1,183 +1,188 @@
 #if _display_symstations == 1
-  LAYER
-    GROUP "default"
-    STATUS ON
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE POINT
-    NAME layername(symstations,_layer_suffix)
-    DATA _symstations_data
-    CLASSITEM "railway"
-
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
+		PROJECTION
+			"init=epsg:OSM_SRID"
+		END
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE POINT
+#if OSM_FORCE_POSTGIS_EXTENT == 1
+		EXTENT OSM_EXTENT
+#endif
+		NAME layername(symstations,_layer_suffix)
+		DATA _symstations_data
+		CLASSITEM "railway"
 #if _display_symstations_bus == 1
-    CLASS
-      EXPRESSION {bus_station}
-      LABEL
+		CLASS
+			EXPRESSION {bus_station}
+			LABEL
 #if _display_symstations_bus_lbl == 1
-        SIZE _symstation_bus_lbl_size
-        COLOR _symstation_bus_lbl_clr
-        TEXT _symstation_bus_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 4
-        POSITION lc
-        FONT _symstation_bus_lbl_font
-        TYPE truetype
-        MAXLENGTH 0
-        ALIGN CENTER
+				SIZE _symstation_bus_lbl_size
+				COLOR _symstation_bus_lbl_clr
+				TEXT _symstation_bus_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 4
+				POSITION lc
+				FONT _symstation_bus_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				ALIGN CENTER
 #endif
-        STYLE
-            SYMBOL _symstation_bus_symbol
-        END
-      END
-    END
-    
-    CLASS
-      EXPRESSION {bus_stop}
-      LABEL
+				STYLE
+					SYMBOL _symstation_bus_symbol
+				END
+			END
+		END
+
+		CLASS
+			EXPRESSION {bus_stop}
+			LABEL
 #if _display_symstations_bus_lbl == 1
-        SIZE _symstation_busstop_lbl_size
-        COLOR _symstation_busstop_lbl_clr
-        TEXT _symstation_busstop_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 4
-        POSITION lc
-        FONT _symstation_busstop_lbl_font
-        TYPE truetype
-        MAXLENGTH 0
-        ALIGN CENTER
+				SIZE _symstation_busstop_lbl_size
+				COLOR _symstation_busstop_lbl_clr
+				TEXT _symstation_busstop_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 4
+				POSITION lc
+				FONT _symstation_busstop_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				ALIGN CENTER
 #endif
-        STYLE
-            SYMBOL _symstation_busstop_symbol
-             SIZE _symstation_busstop_size
-        END
-      END
-    END
+				STYLE
+					SYMBOL _symstation_busstop_symbol
+					SIZE _symstation_busstop_size
+				END
+			END
+		END
 #endif
 
 #if _display_symstations_train == 1
-    CLASS
-      EXPRESSION {station}
-      LABEL 
+		CLASS
+			EXPRESSION {station}
+			LABEL 
 #if _display_symstations_train_lbl == 1          
-        SIZE _symstation_train_lbl_size
-        COLOR _symstation_train_lbl_clr
-        TEXT _symstation_train_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 4
-        POSITION lc
-        FONT _symstation_train_lbl_font
-        TYPE truetype
-        MAXLENGTH 0
-        WRAP " "
-        ALIGN CENTER
-#endif     
-        STYLE
-            SYMBOL _symstation_train_symbol
-            size _symstation_train_size
-        END
-      END
-    END
+				SIZE _symstation_train_lbl_size
+				COLOR _symstation_train_lbl_clr
+				TEXT _symstation_train_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 4
+				POSITION lc
+				FONT _symstation_train_lbl_font
+				TYPE truetype
+				MAXLENGTH 0
+				WRAP " "
+				ALIGN CENTER
+#endif
+				STYLE
+					SYMBOL _symstation_train_symbol
+					SIZE _symstation_train_size
+				END
+			END
+		END
 #endif
 #if _display_symstations_tram == 1
-    CLASS
-      EXPRESSION {tram_stop,halt}
-      LABEL
+		CLASS
+			EXPRESSION {tram_stop,halt}
+			LABEL
 #if _display_symstations_tram_lbl == 1
-        SIZE _symstation_tram_lbl_size
-        COLOR _symstation_tram_lbl_clr
-        TEXT _symstation_tram_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 2
-        POSITION lc
-        FONT _symstation_tram_lbl_font
-        TYPE truetype
-        WRAP " "
-        ALIGN CENTER
-#endif      
-        STYLE
-            SYMBOL _symstation_tram_symbol
-            size _symstation_tram_size
-        END
-      END
-    END
+				SIZE _symstation_tram_lbl_size
+				COLOR _symstation_tram_lbl_clr
+				TEXT _symstation_tram_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 2
+				POSITION lc
+				FONT _symstation_tram_lbl_font
+				TYPE truetype
+				WRAP " "
+				ALIGN CENTER
 #endif
-    
-#if _display_symstations_metro == 1
-    CLASS
-      EXPRESSION ('[metro]' = 'metro')
-      LABEL
-#if _display_symstations_metro_lbl == 1
-        SIZE _symstation_metro_lbl_size
-        COLOR _symstation_metro_lbl_clr
-        TEXT _symstation_metro_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 0
-        POSITION lc
-        FONT _symstation_metro_lbl_font
-        TYPE truetype
-        ALIGN CENTER
-#endif
-        STYLE
-            SYMBOL _symstation_metro_symbol
-            size _symstation_metro_size
-        END
-      END
-    END
-
-    CLASS
-      EXPRESSION ('[railway]' = 'subway_entrance')
-      LABEL
-        PARTIALS false
-        STYLE
-            SYMBOL _symsubway_entrance_symbol
-            size _symsubway_entrance_size
-        END
-      END
-    end
-  END
+				STYLE
+					SYMBOL _symstation_tram_symbol
+					SIZE _symstation_tram_size
+				END
+			END
+		END
 #endif
 
 #if _display_symstations_metro == 1
-  LAYER
-    GROUP "default"
-    STATUS ON
-    CONNECTIONTYPE POSTGIS
-    CONNECTION "OSM_DB_CONNECTION"
-    MINSCALEDENOM _minscale
-    MAXSCALEDENOM _maxscale
-    TYPE POINT
-    NAME layername(symstations_metro,_layer_suffix)
-    DATA _symstations_metro_data
-
-    CLASS
-      LABEL
+		CLASS
+			EXPRESSION ('[metro]' = 'metro')
+			LABEL
 #if _display_symstations_metro_lbl == 1
-        SIZE _symstation_metro_lbl_size
-        COLOR _symstation_metro_lbl_clr
-        TEXT _symstation_metro_lbl_txt
-        OUTLINECOLOR _sym_lbl_ol_clr
-        OUTLINEWIDTH _sym_lbl_ol_width
-        OFFSET 0 0
-        POSITION lc
-        PRIORITY 5
-        FONT _symstation_metro_lbl_font
-        TYPE truetype
-        ALIGN CENTER
-        WRAP " "
+				SIZE _symstation_metro_lbl_size
+				COLOR _symstation_metro_lbl_clr
+				TEXT _symstation_metro_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 0
+				POSITION lc
+				FONT _symstation_metro_lbl_font
+				TYPE truetype
+				ALIGN CENTER
 #endif
-        STYLE
-            SYMBOL _symstation_metro_symbol
-            size _symstation_metro_size
-        END
-      END
-    END
+				STYLE
+					SYMBOL _symstation_metro_symbol
+					SIZE _symstation_metro_size
+				END
+			END
+		END
+
+		CLASS
+			EXPRESSION ('[railway]' = 'subway_entrance')
+			LABEL
+				PARTIALS false
+				STYLE
+					SYMBOL _symsubway_entrance_symbol
+					SIZE _symsubway_entrance_size
+				END
+			END
+		END
+	END
 #endif
-  END
+
+#if _display_symstations_metro == 1
+	LAYER
+		GROUP "default"
+		STATUS ON
+		CONNECTIONTYPE POSTGIS
+		CONNECTION "OSM_DB_CONNECTION"
+		MINSCALEDENOM _minscale
+		MAXSCALEDENOM _maxscale
+		TYPE POINT
+		NAME layername(symstations_metro,_layer_suffix)
+		DATA _symstations_metro_data
+
+		CLASS
+			LABEL
+#if _display_symstations_metro_lbl == 1
+				SIZE _symstation_metro_lbl_size
+				COLOR _symstation_metro_lbl_clr
+				TEXT _symstation_metro_lbl_txt
+				OUTLINECOLOR _sym_lbl_ol_clr
+				OUTLINEWIDTH _sym_lbl_ol_width
+				OFFSET 0 0
+				POSITION lc
+				PRIORITY 5
+				FONT _symstation_metro_lbl_font
+				TYPE truetype
+				ALIGN CENTER
+				WRAP " "
+#endif
+				STYLE
+					SYMBOL _symstation_metro_symbol
+					SIZE _symstation_metro_size
+				END
+			END
+		END
+#endif
+	END
 #endif


### PR DESCRIPTION
- A new style has been added that adds house numbers and place names to the map in zoom levels 17 and 18.
- Projection and extent information have been added to the symbol layer template mapfiles in order to speed up generation of the GetCapabilities document. Without these information Mapserver will traverse the entire database tables in order to determine the layer bounds.
- A homogeneous indentation hase been applied to all layer template mapfiles improving readability of the resulting complete mapfile.