### PR TITLE
included address information attached to buildings in imposm import mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ boundaries.sql: boundaries.sql.in
 post-symbols.sql: post-symbols.sql.in
 	cp -f $< $@
 	$(SED) -e 's/OSM_PREFIX_/$(OSM_PREFIX)/g' $@
+	$(SED) -e 's/OSM_SRID/$(OSM_SRID)/g' $@
+	$(SED) -e 's/OSM_NAME_COLUMN/$(OSM_NAME_COLUMN)/g' $@
 	$(info ********** Important notice regarding additional symbol layers **********)
 	$(info If you haven't done so already please execute SQL script post-symbols.sql)
 	$(info on your OSM database. The script creates additional indexes and views)

--- a/generate_style.py
+++ b/generate_style.py
@@ -1196,8 +1196,7 @@ namedstyles = {
 		'tertiary_ol_clr': '193 181 157',
 		'other_ol_clr': '193 181 157',
 		'pedestrian_ol_clr': '193 181 157',
-		'pier_ol_clr': '193 181 157',
-		'display_buildings': 1
+		'pier_ol_clr': '193 181 157'
 	},
 	'michelin': {
 		'motorway_clr': '228 24 24',
@@ -1637,7 +1636,6 @@ namedstyles = {
 	'housenumbers': {
 		# begin displaying housenumbers at z17
 		'display_housenumbers': {0: 0, 17: 1},
-
 
 		'housenumbers_data': {
 			0: 'nodata',

--- a/generate_style.py
+++ b/generate_style.py
@@ -1641,8 +1641,8 @@ namedstyles = {
 
 		'housenumbers_data': {
 			0: 'nodata',
-			17: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, type AS label, osm_id FROM OSM_PREFIX_housenumbers) AS numbers) as foo using unique osm_id using srid=OSM_SRID"',
-			18: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, CASE WHEN name <> \'\' AND type <> \'\' THEN name || \' (\' || type || \')\' WHEN name <> \'\' THEN name ELSE type END AS label, osm_id FROM OSM_PREFIX_housenumbers) AS numbers) as foo using unique osm_id using srid=OSM_SRID"'
+			17: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, housenumber AS label, id FROM v_OSM_PREFIX_housenumbers_buildings) AS numbers) as foo using unique id using srid=OSM_SRID"',
+			18: '"geometry from (SELECT *, NULL AS nullid FROM (SELECT GEOMETRY as geometry, CASE WHEN name <> \'\' AND housenumber <> \'\' THEN name || \' (\' || housenumber || \')\' WHEN name <> \'\' THEN name ELSE housenumber END AS label, id FROM v_OSM_PREFIX_housenumbers_buildings) AS numbers) as foo using unique id using srid=OSM_SRID"'
 		},
 
 		'housenumbers_lbl_size': {

--- a/imposm3-mapping-symbols-housenumbers.json
+++ b/imposm3-mapping-symbols-housenumbers.json
@@ -1,0 +1,945 @@
+{
+  "tags": {
+    "load_all": true,
+    "exclude": ["created_by", "source", "tiger:*"]
+  },
+  "generalized_tables": {
+        "waterareas_gen1": {
+            "source": "waterareas",
+            "sql_filter": "ST_Area(geometry)>50000.000000",
+            "tolerance": 50.0
+        },
+        "waterareas_gen0": {
+            "source": "waterareas_gen1",
+            "sql_filter": "ST_Area(geometry)>500000.000000",
+            "tolerance": 200.0
+        },
+        "roads_gen0": {
+            "source": "roads_gen1",
+            "sql_filter": null,
+            "tolerance": 200.0
+        },
+        "roads_gen1": {
+            "source": "roads",
+            "sql_filter": "type IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link')",
+            "tolerance": 50.0
+        },
+        "railways": {
+            "source": "roads",
+            "sql_filter": "type IN ('rail', 'tram', 'light_rail', 'subway', 'narrow_gauge', 'preserved', 'funicular', 'monorail')"
+        },
+        "railways_gen1": {
+            "source": "railways",
+            "sql_filter": null,
+            "tolerance": 50.0
+        },
+        "railways_gen0": {
+            "source": "railways_gen1",
+            "sql_filter": null,
+            "tolerance": 200.0
+        },
+        "waterways_gen0": {
+            "source": "waterways_gen1",
+            "sql_filter": "type IN ('river', 'canal')",
+            "tolerance": 200
+        },
+        "waterways_gen1": {
+            "source": "waterways",
+            "sql_filter": "type IN ('river', 'canal', 'stream')",
+            "tolerance": 50.0
+        },
+        "landusages_gen1": {
+            "source": "landusages",
+            "sql_filter": "ST_Area(geometry)>50000.000000",
+            "tolerance": 50.0
+        },
+        "landusages_gen0": {
+            "source": "landusages_gen1",
+            "sql_filter": "type IN ('forest', 'wood') AND ST_Area(geometry)>500000.000000",
+            "tolerance": 200.0
+        },
+        "landusages_gen00": {
+            "source": "landusages_gen0",
+            "sql_filter": "type IN ('forest', 'wood') AND ST_Area(geometry)>1000000.000000",
+            "tolerance": 500.0
+        }
+    },
+    "tables": {
+        "landusages": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "webmerc_area",
+                    "name": "area",
+                    "key": null
+                },
+                {
+                    "args": {
+                        "values": [
+                            "land",
+                            "island",
+                            "heath",
+                            "railway",
+                            "industrial",
+                            "commercial",
+                            "retail",
+                            "residential",
+                            "quarry",
+                            "zoo",
+                            "vineyard",
+                            "orchard",
+                            "scrub",
+                            "hospital",
+                            "place_of_worship",
+                            "theatre",
+                            "cinema",
+                            "nature_reserve",
+                            "parking",
+                            "fuel",
+                            "baracks",
+                            "library",
+                            "college",
+                            "school",
+                            "university",
+                            "golf_course",
+                            "allotments",
+                            "common",
+                            "pitch",
+                            "sports_centre",
+                            "garden",
+                            "recreation_ground",
+                            "village_green",
+                            "wetland",
+                            "grass",
+                            "meadow",
+                            "wood",
+                            "farmland",
+                            "farm",
+                            "farmyard",
+                            "cemetery",
+                            "forest",
+                            "park",
+                            "playground",
+                            "footway",
+                            "pedestrian"
+                        ]
+                    },
+                    "type": "enumerate",
+                    "name": "z_order"
+                },
+              {
+                    "type": "hstore_tags",
+                    "name": "tags",
+                    "key": null
+              }
+            ],
+            "type": "polygon",
+            "mapping": {
+              "landuse": [
+                "park",
+                "forest",
+                "residential",
+                "retail",
+                "commercial",
+                "industrial",
+                "railway",
+                "cemetery",
+                "grass",
+                "farmyard",
+                "farm",
+                "farmland",
+                "orchard",
+                "vineyard",
+                "wood",
+                "meadow",
+                "village_green",
+                "recreation_ground",
+                "allotments",
+                "quarry"
+              ],
+              "leisure": [
+                "park",
+                "garden",
+                "playground",
+                "golf_course",
+                "sports_centre",
+                "pitch",
+                "stadium",
+                "common",
+                "nature_reserve", "water_park", "miniature_golf",  "picnic_table"
+              ],
+              "natural": ["wood","land","scrub","wetland","heath", "spring", "peak"],
+              "highway": [
+                "pedestrian",
+                "footway", "bus_stop", "elevator", "traffic_signals"
+              ],
+              "amenity": [
+                "university", "school", "college",
+                "hospital", "shelter", "atm", "bank", "bar", "bicycle_rental", "bus_station", "cafe", "car_rental", "car_wash",
+                "cinema", "clinic", "community_centre", "fire_station", "fountain", "fuel", "hospital", "ice_cream",
+                "embassy", "library", "courthouse", "townhall", "parking", "bicycle_parking", "motorcycle_parking", "pharmacy",
+                "doctors", "dentist", "place_of_worship", "police", "post_box", "post_office", "pub", "biergarten", "recycling",
+                "restaurant", "food_court", "fast_food", "telephone", "emergency_phone", "taxi", "theatre", "toilets", "drinking_water",
+                "prison", "hunting_stand", "nightclub", "veterinary", "social_facility", "charging_station"
+              ],
+              "barrier": [
+                "hedge"
+              ],
+              "tourism": [
+                "gallery","zoo", "artwork", "alpine_hut", "camp_site", "caravan_site", "chalet", "guest_house", "hostel", "hotel", "motel", "information", "museum", "viewpoint", "picnic_site"
+              ],
+              "man_made": [
+                "pier", "mast", "water_tower", "lighthouse", "windmill", "obelisk"
+              ],
+              "aeroway": [
+                "runway",
+                "taxiway"
+              ],
+              "place": [
+                "island"
+              ],
+              "military": [
+                "barracks"
+              ],
+              "shop": ["supermarket", "bag", "bakery", "beauty", "books", "butcher", "clothes", "computer", "confectionery", "fashion",
+                "convenience", "department_store", "doityourself", "hardware", "fishmonger", "florist", "garden_centre", "hairdresser",
+                "hifi", "ice_cream", "car", "car_repair", "bicycle", "mall", "pet", "photo", "photo_studio", "photography", "seafood",
+                "shoes", "alcohol", "gift", "furniture", "kiosk", "mobile_phone", "motorcycle", "musical_instrument", "newsagent",
+                "optician", "jewelry", "jewellery", "electronics", "chemist", "toys", "travel_agency", "car_parts", "greengrocer",
+                "farm", "stationery", "laundry", "dry_cleaning", "beverages", "perfumery", "cosmetics", "variety_store", "wine", "outdoor",
+                "copyshop", "sports", "deli", "tobacco", "art", "tea"],
+              "historic": ["memorial", "monument", "archaeological_site"],
+              "power": ["generator"],
+              "generator_source": ["wind"],
+              "power_source": ["wind"]
+            }
+        },
+        "buildings": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+				{
+                    "type": "string",
+                    "name": "addr:street",
+                    "key": "addr:street"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:postcode",
+                    "key": "addr:postcode"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:city",
+                    "key": "addr:city"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:country",
+                    "key": "addr:country"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:housenumber",
+                    "key": "addr:housenumber"
+                }
+            ],
+            "type": "polygon",
+            "mapping": {
+                "building": [
+                    "__any__"
+                ]
+            }
+        },
+        "places": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "args": {
+                        "values": [
+                            "locality",
+                            "suburb",
+                            "hamlet",
+                            "village",
+                            "town",
+                            "city",
+                            "county",
+                            "region",
+                            "state",
+                            "country"
+                        ]
+                    },
+                    "type": "enumerate",
+                    "name": "z_order"
+                },
+                {
+                    "type": "integer",
+                    "name": "population",
+                    "key": "population"
+                }
+            ],
+            "type": "point",
+            "mapping": {
+                "place": [
+                    "country",
+                    "state",
+                    "region",
+                    "county",
+                    "city",
+                    "town",
+                    "village",
+                    "hamlet",
+                    "suburb",
+                    "locality"
+                ]
+            }
+        },
+        "transport_areas": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                }
+            ],
+            "type": "polygon",
+            "mapping": {
+                "railway": [
+                    "station",
+                    "platform"
+                ],
+                "aeroway": [
+                    "aerodrome",
+                    "terminal",
+                    "helipad",
+                    "apron"
+                ]
+            }
+        },
+        "admin": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "integer",
+                    "name": "admin_level",
+                    "key": "admin_level"
+                }
+            ],
+            "type": "polygon",
+            "mapping": {
+                "boundary": [
+                    "administrative"
+                ]
+            }
+        },
+        "aeroways": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                }
+            ],
+            "type": "linestring",
+            "mapping": {
+                "aeroway": [
+                    "runway",
+                    "taxiway"
+                ]
+            }
+        },
+        "waterways": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                }
+            ],
+            "type": "linestring",
+            "mapping": {
+                "waterway": [
+                    "stream",
+                    "river",
+                    "canal",
+                    "drain",
+                    "ditch"
+                ],
+                "barrier": [
+                    "ditch"
+                ]
+            }
+        },
+        "barrierways": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                }
+            ],
+            "type": "linestring",
+            "mapping": {
+                "barrier": [
+                    "city_wall",
+                    "fence",
+                    "hedge",
+                    "retaining_wall",
+                    "wall",
+                    "bollard",
+                    "gate",
+                    "spikes",
+                    "lift_gate",
+                    "kissing_gate",
+                    "embankment",
+                    "yes",
+                    "wire_fence"
+                ]
+            }
+        },
+        "transport_points": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "ref",
+                    "key": "ref"
+                },
+              {
+                    "type": "hstore_tags",
+                    "name": "tags",
+                    "key": null
+              }
+            ],
+            "type": "point",
+            "mapping": {
+                "railway": [
+                    "station",
+                    "halt",
+                    "tram_stop",
+                    "crossing",
+                    "level_crossing",
+                    "subway_entrance"
+                ],
+                "aeroway": [
+                    "aerodrome",
+                    "terminal",
+                    "helipad",
+                    "gate"
+                ],
+                "aerialway" : ["station"],
+                "public_transport" : ["station"],
+                "highway": [
+                    "motorway_junction",
+                    "turning_circle",
+                    "bus_stop"
+                ]
+            }
+        },
+        "amenities": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+              {
+                    "type": "hstore_tags",
+                    "name": "tags",
+                    "key": null
+              }
+            ],
+            "type": "point",
+            "mapping": {
+              "amenity": ["__any__"],
+              "shop": [ "__any__"],
+              "tourism": [ "artwork", "alpine_hut", "camp_site", "caravan_site", "chalet", "guest_house", "hostel", "hotel",
+                          "motel", "information", "museum", "viewpoint", "picnic_site"],
+              "leisure":  ["water_park", "playground", "miniature_golf", "golf_course", "picnic_table"],
+              "man_made": [ "mast", "water_tower", "lighthouse", "windmill", "obelisk"],
+              "natural": [ "spring", "peak"],
+              "historic": [ "memorial", "monument", "archaeological_site"],
+              "highway": [ "bus_stop", "elevator", "traffic_signals"],
+              "power": [ "generator"],
+            }
+        },
+        "barrierpoints": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                }
+            ],
+            "type": "point",
+            "mapping": {
+                "barrier": [
+                    "block",
+                    "bollard",
+                    "cattle_grid",
+                    "chain",
+                    "cycle_barrier",
+                    "entrance",
+                    "horse_stile",
+                    "gate",
+                    "spikes",
+                    "lift_gate",
+                    "kissing_gate",
+                    "fence",
+                    "yes",
+                    "wire_fence",
+                    "toll_booth",
+                    "stile"
+                ]
+            }
+        },
+        "housenumbers_interpolated": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "addr:street",
+                    "key": "addr:street"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:postcode",
+                    "key": "addr:postcode"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:city",
+                    "key": "addr:city"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:inclusion",
+                    "key": "addr:inclusion"
+                }
+            ],
+            "type": "linestring",
+            "mapping": {
+                "addr:interpolation": [
+                    "__any__"
+                ]
+            }
+        },
+        "roads": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "boolint",
+                    "name": "tunnel",
+                    "key": "tunnel"
+                },
+                {
+                    "type": "boolint",
+                    "name": "bridge",
+                    "key": "bridge"
+                },
+                {
+                    "type": "direction",
+                    "name": "oneway",
+                    "key": "oneway"
+                },
+                {
+                    "type": "string",
+                    "name": "ref",
+                    "key": "ref"
+                },
+                {
+                    "type": "wayzorder",
+                    "name": "z_order",
+                    "key": "layer"
+                },
+                {
+                    "type": "string",
+                    "name": "access",
+                    "key": "access"
+                },
+                {
+                    "type": "string",
+                    "name": "service",
+                    "key": "service"
+                },
+                {
+                    "type": "mapping_key",
+                    "name": "class",
+                    "key": null
+                }
+            ],
+            "type": "linestring",
+            "filters": {
+                "reject": {
+                    "area": [ "yes" ]
+                }
+            },
+            "mappings": {
+                "railway": {
+                    "mapping": {
+                        "railway": [
+                            "rail",
+                            "tram",
+                            "light_rail",
+                            "subway",
+                            "narrow_gauge",
+                            "preserved",
+                            "funicular",
+                            "monorail",
+                            "disused"
+                        ]
+                    }
+                },
+                "roads": {
+                    "mapping": {
+                        "man_made": [
+                            "pier",
+                            "groyne"
+                        ],
+                        "highway": [
+                            "motorway",
+                            "motorway_link",
+                            "trunk",
+                            "trunk_link",
+                            "primary",
+                            "primary_link",
+                            "secondary",
+                            "secondary_link",
+                            "tertiary",
+                            "tertiary_link",
+                            "road",
+                            "path",
+                            "track",
+                            "service",
+                            "footway",
+                            "bridleway",
+                            "cycleway",
+                            "steps",
+                            "pedestrian",
+                            "living_street",
+                            "unclassified",
+                            "residential",
+                            "raceway"
+                        ]
+                    }
+                }
+            }
+        },
+        "housenumbers": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "addr:street",
+                    "key": "addr:street"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:postcode",
+                    "key": "addr:postcode"
+                },
+                {
+                    "type": "string",
+                    "name": "addr:city",
+                    "key": "addr:city"
+                }
+            ],
+            "type": "point",
+            "mapping": {
+                "addr:housenumber": [
+                    "__any__"
+                ]
+            }
+        },
+        "waterareas": {
+            "columns": [
+                {
+                    "type": "id",
+                    "name": "osm_id",
+                    "key": null
+                },
+                {
+                    "type": "geometry",
+                    "name": "geometry",
+                    "key": null
+                },
+                {
+                    "type": "string",
+                    "name": "name",
+                    "key": "name"
+                },
+                {
+                    "type": "mapping_value",
+                    "name": "type",
+                    "key": null
+                },
+                {
+                    "type": "webmerc_area",
+                    "name": "area",
+                    "key": null
+                }
+            ],
+            "type": "polygon",
+            "mapping": {
+                "waterway": [
+                    "riverbank",
+                    "dock"
+                ],
+                "landuse": [
+                    "basin",
+                    "reservoir"
+                ],
+                "natural": [
+                    "water"
+                ],
+                "amenity": [
+                    "swimming_pool"
+                ],
+                "leisure": [
+                    "swimming_pool"
+                ]
+            }
+        }
+    }
+}

--- a/post-symbols.sql.in
+++ b/post-symbols.sql.in
@@ -3,65 +3,81 @@
 -- SQL to launch after imposm3 import when using imposm3-mapping-symbols.json mapping:
 
 -- index from where clauses in the data
-create index on OSM_PREFIX_amenities using gin(tags);
-create index on OSM_PREFIX_transport_points using gin(tags);
-create index on OSM_PREFIX_transport_points using gin((tags->'{railway, aerialway,public_transport}'::text[]));
-create index on OSM_PREFIX_transport_areas (type);
-create index on OSM_PREFIX_waterways_gen0 (type);
-create index on OSM_PREFIX_waterways_gen1 (type);
-create index on OSM_PREFIX_roads_gen0 (type);
-create index on OSM_PREFIX_roads_gen1 (type);
-create index on OSM_PREFIX_roads (z_order);
-create index on OSM_PREFIX_roads (st_length(geometry));
-create index on OSM_PREFIX_railways_gen0 (type);
-create index on OSM_PREFIX_railways_gen1 (type);
-create index on OSM_PREFIX_railways (type);
-create index on OSM_PREFIX_landusages_gen1 (type);
-create index on OSM_PREFIX_landusages using gin(tags);
-create index on OSM_PREFIX_landusages ((tags->'shop'));
-create index on OSM_PREFIX_landusages using gin((tags->'{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]));
-create index on OSM_PREFIX_landusages (type);
-create index on OSM_PREFIX_places (type);
+create index if not exists OSM_PREFIX_amenities_tags_idx on OSM_PREFIX_amenities using gin(tags);
+create index if not exists OSM_PREFIX_transport_points_tags_idx on OSM_PREFIX_transport_points using gin(tags);
+create index if not exists OSM_PREFIX_transport_points_expr_idx on OSM_PREFIX_transport_points using gin((tags->'{railway, aerialway,public_transport}'::text[]));
+create index if not exists OSM_PREFIX_transport_areas_type_idx on OSM_PREFIX_transport_areas (type);
+create index if not exists OSM_PREFIX_waterways_gen0_type_idx on OSM_PREFIX_waterways_gen0 (type);
+create index if not exists OSM_PREFIX_waterways_gen1_type_idx on OSM_PREFIX_waterways_gen1 (type);
+create index if not exists OSM_PREFIX_roads_gen0_type_idx on OSM_PREFIX_roads_gen0 (type);
+create index if not exists OSM_PREFIX_roads_gen1_type_idx on OSM_PREFIX_roads_gen1 (type);
+create index if not exists OSM_PREFIX_roads_z_order_idx on OSM_PREFIX_roads (z_order);
+create index if not exists OSM_PREFIX_roads_st_length_idx on OSM_PREFIX_roads (st_length(geometry));
+create index if not exists OSM_PREFIX_railways_gen0_type_idx on OSM_PREFIX_railways_gen0 (type);
+create index if not exists OSM_PREFIX_railways_gen1_type_idx on OSM_PREFIX_railways_gen1 (type);
+create index if not exists OSM_PREFIX_railways_type_idx on OSM_PREFIX_railways (type);
+create index if not exists OSM_PREFIX_landusages_gen1_type_idx on OSM_PREFIX_landusages_gen1 (type);
+create index if not exists OSM_PREFIX_landusages_tags_idx on OSM_PREFIX_landusages using gin(tags);
+create index if not exists OSM_PREFIX_landusages_expr_idx on OSM_PREFIX_landusages ((tags->'shop'));
+create index if not exists OSM_PREFIX_landusages_expr_idx1 on OSM_PREFIX_landusages using gin((tags->'{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]));
+create index if not exists OSM_PREFIX_landusages_type_idx on OSM_PREFIX_landusages (type);
+create index if not exists OSM_PREFIX_places_type_idx on OSM_PREFIX_places (type);
+
+-- create materialized view to combine housenumbers from various tables and speed up display
+create materialized view if not exists v_OSM_PREFIX_housenumbers_buildings
+as
+	select uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) as id,
+		OSM_PREFIX_housenumbers.geometry,
+		OSM_PREFIX_housenumbers.osm_id,
+		OSM_PREFIX_housenumbers.OSM_NAME_COLUMN,
+		OSM_PREFIX_housenumbers.type as housenumber,
+		OSM_PREFIX_housenumbers."addr:street",
+		OSM_PREFIX_housenumbers."addr:postcode",
+		OSM_PREFIX_housenumbers."addr:city"
+	from OSM_PREFIX_housenumbers
+union all
+	select uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) as id,
+		case when st_intersects(st_centroid(OSM_PREFIX_buildings.geometry), OSM_PREFIX_buildings.geometry) then st_centroid(OSM_PREFIX_buildings.geometry) else st_pointonsurface(OSM_PREFIX_buildings.geometry) end as geometry,
+		OSM_PREFIX_buildings.osm_id,
+		OSM_PREFIX_buildings.OSM_NAME_COLUMN,
+		OSM_PREFIX_buildings."addr:housenumber" as housenumber,
+		OSM_PREFIX_buildings."addr:street",
+		OSM_PREFIX_buildings."addr:postcode",
+		OSM_PREFIX_buildings."addr:city"
+	from OSM_PREFIX_buildings
+	where (OSM_PREFIX_buildings."addr:housenumber" is not null and OSM_PREFIX_buildings."addr:housenumber" <> '')
+with data;
+
+create unique index if not exists v_OSM_PREFIX_housenumbers_buildings_idx on v_OSM_PREFIX_housenumbers_buildings (id);
+create index if not exists v_OSM_PREFIX_housenumbers_buildings_geom on v_OSM_PREFIX_housenumbers_buildings using gist(geometry);
+create index if not exists v_OSM_PREFIX_housenumbers_buildings_geom_geohash on v_OSM_PREFIX_housenumbers_buildings using btree(st_geohash(st_transform(st_setsrid(box2d(geometry)::geometry, OSM_SRID), 4326)));
 
 -- create materialized view to significantly speed up display of symbols
-CREATE MATERIALIZED VIEW public.v_OSM_PREFIX_symbols_amenities_landusages
-TABLESPACE pg_default
-AS
- SELECT OSM_PREFIX_amenities.geometry,
-    OSM_PREFIX_amenities.osm_id,
-    OSM_PREFIX_amenities.OSM_NAME_COLUMN,
-    OSM_PREFIX_amenities.tags
-   FROM OSM_PREFIX_amenities
-  WHERE (OSM_PREFIX_amenities.tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]) && '{marketplace,artwork,alpine_hut,camp_site,caravan_site,chalet,guest_house,hostel,hotel,motel,information,museum,viewpoint,picnic_site,shelter,atm,bank,bar,bicycle_rental,bus_station,cafe,car_rental,car_wash,cinema,clinic,community_centre,fire_station,fountain,fuel,hospital,ice_cream,embassy,library,courthouse,townhall,parking,bicycle_parking,motorcycle_parking,pharmacy,doctors,dentist,place_of_worship,police,post_box,post_office,pub,biergarten,recycling,restaurant,food_court,fast_food,telephone,emergency_phone,taxi,theatre,toilets,drinking_water,prison,hunting_stand,nightclub,veterinary,social_facility,charging_station,water_park,playground,miniature_golf,golf_course,picnic_table,mast,water_tower,lighthouse,windmill,obelisk,spring,memorial,monument,archaeological_site,bus_stop,elevator,traffic_signals,wind,peak}'::text[] OR (OSM_PREFIX_amenities.tags -> 'shop'::text) IS NOT NULL
-UNION ALL
- SELECT st_centroid(OSM_PREFIX_landusages.geometry) AS geometry,
-    OSM_PREFIX_landusages.osm_id,
-    OSM_PREFIX_landusages.OSM_NAME_COLUMN,
-    OSM_PREFIX_landusages.tags
-   FROM OSM_PREFIX_landusages
-  WHERE (OSM_PREFIX_landusages.tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]) && '{artwork,alpine_hut,camp_site,caravan_site,chalet,guest_house,hostel,hotel,motel,information,museum,viewpoint,picnic_site,shelter,atm,bank,bar,bicycle_rental,bus_station,cafe,car_rental,car_wash,cinema,clinic,community_centre,fire_station,fountain,fuel,hospital,ice_cream,embassy,library,courthouse,townhall,parking,bicycle_parking,motorcycle_parking,pharmacy,doctors,dentist,place_of_worship,police,post_box,post_office,pub,biergarten,recycling,restaurant,food_court,fast_food,telephone,emergency_phone,taxi,theatre,toilets,drinking_water,prison,hunting_stand,nightclub,veterinary,social_facility,charging_station,water_park,playground,miniature_golf,golf_course,picnic_table,mast,water_tower,lighthouse,windmill,obelisk,spring,memorial,monument,archaeological_site,bus_stop,elevator,traffic_signals,generator,wind,peak}'::text[] OR (OSM_PREFIX_landusages.tags -> 'shop'::text) IS NOT NULL
-WITH DATA;
+create materialized view if not exists v_OSM_PREFIX_symbols_amenities_landusages
+as
+	select uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) as id,
+		OSM_PREFIX_amenities.geometry,
+		OSM_PREFIX_amenities.osm_id,
+		OSM_PREFIX_amenities.OSM_NAME_COLUMN,
+		OSM_PREFIX_amenities.tags
+	from OSM_PREFIX_amenities
+	where (OSM_PREFIX_amenities.tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]) && '{marketplace,artwork,alpine_hut,camp_site,caravan_site,chalet,guest_house,hostel,hotel,motel,information,museum,viewpoint,picnic_site,shelter,atm,bank,bar,bicycle_rental,bus_station,cafe,car_rental,car_wash,cinema,clinic,community_centre,fire_station,fountain,fuel,hospital,ice_cream,embassy,library,courthouse,townhall,parking,bicycle_parking,motorcycle_parking,pharmacy,doctors,dentist,place_of_worship,police,post_box,post_office,pub,biergarten,recycling,restaurant,food_court,fast_food,telephone,emergency_phone,taxi,theatre,toilets,drinking_water,prison,hunting_stand,nightclub,veterinary,social_facility,charging_station,water_park,playground,miniature_golf,golf_course,picnic_table,mast,water_tower,lighthouse,windmill,obelisk,spring,memorial,monument,archaeological_site,bus_stop,elevator,traffic_signals,wind,peak}'::text[] OR (OSM_PREFIX_amenities.tags -> 'shop'::text) is not null
+union all
+	select uuid_in(md5(random()::text || clock_timestamp()::text)::cstring) as id,
+		st_centroid(OSM_PREFIX_landusages.geometry) as geometry,
+		OSM_PREFIX_landusages.osm_id,
+		OSM_PREFIX_landusages.OSM_NAME_COLUMN,
+		OSM_PREFIX_landusages.tags
+	from OSM_PREFIX_landusages
+	where (OSM_PREFIX_landusages.tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]) && '{artwork,alpine_hut,camp_site,caravan_site,chalet,guest_house,hostel,hotel,motel,information,museum,viewpoint,picnic_site,shelter,atm,bank,bar,bicycle_rental,bus_station,cafe,car_rental,car_wash,cinema,clinic,community_centre,fire_station,fountain,fuel,hospital,ice_cream,embassy,library,courthouse,townhall,parking,bicycle_parking,motorcycle_parking,pharmacy,doctors,dentist,place_of_worship,police,post_box,post_office,pub,biergarten,recycling,restaurant,food_court,fast_food,telephone,emergency_phone,taxi,theatre,toilets,drinking_water,prison,hunting_stand,nightclub,veterinary,social_facility,charging_station,water_park,playground,miniature_golf,golf_course,picnic_table,mast,water_tower,lighthouse,windmill,obelisk,spring,memorial,monument,archaeological_site,bus_stop,elevator,traffic_signals,generator,wind,peak}'::text[] OR (OSM_PREFIX_landusages.tags -> 'shop'::text) is not null
+with data;
 
-CREATE INDEX v_OSM_PREFIX_symbols_amenities_landusages_expr_idx1
-    ON public.v_OSM_PREFIX_symbols_amenities_landusages USING gin
-    ((tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]) COLLATE pg_catalog."default")
-    TABLESPACE pg_default;
-CREATE INDEX v_OSM_PREFIX_symbols_amenities_landusages_geom
-    ON public.v_OSM_PREFIX_symbols_amenities_landusages USING gist
-    (geometry)
-    TABLESPACE pg_default;
-CREATE INDEX v_OSM_PREFIX_symbols_amenities_landusages_geom_geohash
-    ON public.v_OSM_PREFIX_symbols_amenities_landusages USING btree
-    (st_geohash(st_transform(st_setsrid(box2d(geometry)::geometry, 3857), 4326)) COLLATE pg_catalog."default")
-    TABLESPACE pg_default;
-CREATE INDEX v_OSM_PREFIX_symbols_amenities_landusages_idx
-    ON public.v_OSM_PREFIX_symbols_amenities_landusages USING btree
-    ((tags -> 'shop'::text) COLLATE pg_catalog."default")
-    TABLESPACE pg_default;
-CREATE INDEX v_OSM_PREFIX_symbols_amenities_landusages_tags_idx
-    ON public.v_OSM_PREFIX_symbols_amenities_landusages USING gin
-    (tags)
-    TABLESPACE pg_default;
+create unique index if not exists v_OSM_PREFIX_symbols_amenities_landusages_idx on v_OSM_PREFIX_symbols_amenities_landusages (id);
+create index if not exists v_OSM_PREFIX_symbols_amenities_landusages_geom on v_OSM_PREFIX_symbols_amenities_landusages using gist(geometry);
+create index if not exists v_OSM_PREFIX_symbols_amenities_landusages_geom_geohash on v_OSM_PREFIX_symbols_amenities_landusages using btree(st_geohash(st_transform(st_setsrid(box2d(geometry)::geometry, OSM_SRID), 4326)));
+create index if not exists v_OSM_PREFIX_symbols_amenities_landusages_tags_idx on v_OSM_PREFIX_symbols_amenities_landusages using gin(tags);
+create index if not exists v_OSM_PREFIX_symbols_amenities_landusages_expr_idx on v_OSM_PREFIX_symbols_amenities_landusages ((tags -> 'shop'::text));
+create index if not exists v_OSM_PREFIX_symbols_amenities_landusages_expr_idx1 on v_OSM_PREFIX_symbols_amenities_landusages using gin((tags -> '{tourism,amenity,shop,leisure,man_made,natural,historic,highway,power,generator_source,power_source}'::text[]));
 
 vacuum analyse OSM_PREFIX_amenities;
 vacuum analyse OSM_PREFIX_transport_points;


### PR DESCRIPTION
- A new imposm import mapping has been added incorporating address information attached to building objects
-  `if not exist` guards and missing Makefile variable placeholders have been added to SQL statements `post-symbols.sql.in`
- Database structure has been further optimized to speed up queries on symbol and housenumber tables/views